### PR TITLE
Libpitt/ga4 177

### DIFF
--- a/src/components/custom/Login.jsx
+++ b/src/components/custom/Login.jsx
@@ -42,7 +42,7 @@ function Login() {
                                     className={'d-flex justify-content-center'}
                                 >
                                     <a
-                                        className="btn btn-outline-success rounded-0 btn-lg"
+                                        className="btn btn-outline-success rounded-0 btn-lg js-btn--login"
                                         href={loginUrl}
                                     >
                                         {_t('Log in with your institution credentials')}

--- a/src/components/custom/js/addons/Addon.js
+++ b/src/components/custom/js/addons/Addon.js
@@ -1,9 +1,21 @@
 import $ from 'jquery'
 class Addon {
+    route;
+
     constructor(el, args) {
         this.el = $(el)
         this.app = args.app
         this.data = args.data
+        this.user = {}
+        this.router = args.router
+        this.entities = args.entities
+        if (args.data && args.data.user) {
+            this.user = JSON.parse(args.data.user)
+        }
+        if (Addon.isLocal()) {
+            Addon.log('Addons args:', 'log', 'aqua')
+            console.log(args)
+        }
         this.keycodes = {
             enter: 'Enter',
             esc: 'Escape'
@@ -47,8 +59,12 @@ class Addon {
         return e.code === this.keycodes.esc
     }
 
+    static isLocal() {
+        return (location.host.indexOf('localhost') !== -1)
+    }
+
     static log(msg, fn = 'log', color = '#bada55') {
-        if (location.host.indexOf('localhost') !== -1) {
+        if (Addon.isLocal()) {
             console[fn](`%c ${msg}`, `background: #222; color: ${color}`)
         }
     }

--- a/src/components/custom/js/addons/GoogleTagManager.js
+++ b/src/components/custom/js/addons/GoogleTagManager.js
@@ -89,7 +89,7 @@ class GoogleTagManager extends Addon {
     handleLinks(e) {
         this.event = 'links'
         const $el = this.currentTarget(e)
-        this.gtm({link: $el.text() || $el.attr('aria-label')})
+        this.gtm({link: $el.text() || $el.attr('aria-label') || $el.attr('alt')})
     }
 
     links() {

--- a/src/components/custom/js/addons/GoogleTagManager.js
+++ b/src/components/custom/js/addons/GoogleTagManager.js
@@ -103,11 +103,11 @@ class GoogleTagManager extends Addon {
         const className = $el.attr('class')
         this.event = 'cta'
         let action
-        if (className.includes('json')){
-            action = 'json'
-        }
-        if (className.includes('submit')) {
-            action = 'submit'
+        const actions = ['json', 'submit', 'login']
+        for (let i = 0; i < actions.length; i++) {
+            if (className.includes(actions[i])){
+                action = actions[i]
+            }
         }
         if (action) {
             let data = { }
@@ -133,7 +133,9 @@ class GoogleTagManager extends Addon {
     }
 
     getUuid() {
-        return this.router.asPath.split('uuid=')[1].split('&')[0] // Fully fetch the uuid, split(&)[0] in case more params follow
+        const uuid = this.router.asPath.split('uuid=')
+        // Fully fetch the uuid, split(&)[0] in case more params follow
+        return uuid.length && uuid.length > 1 ? this.router.asPath.split('uuid=')[1].split('&')[0] : null
     }
 
     entityPage(data, send = true) {
@@ -165,12 +167,20 @@ class GoogleTagManager extends Addon {
         }
         return data
     }
-
+    getPerson(bto = false) {
+        const id = this.user.email
+        let result
+        if (id) {
+            result = bto ? btoa(id.replace('@', '*')) : `${id.split('@')[0]}***`
+        }
+        return result
+    }
     gtm(args) {
         let data = {
             event: this.event,
             path: this.getPath(),
-            user_id: this.user.email,
+            person: this.getPerson(),
+            user_id: this.getPerson(true),
             globus_id: this.user.globus_id,
             session: (this.user.email !== undefined), ...args
         }

--- a/src/components/custom/js/addons/addons.js
+++ b/src/components/custom/js/addons/addons.js
@@ -21,16 +21,17 @@ function addons(source, args) {
     }
 
     setTimeout(() => {
+
         for (let app in apps) {
             document
                 .querySelectorAll(`[class*='js-${app}--'], [data-js-${app}]`)
                 .forEach((el) => {
-                    new apps[app](el, {app, data: args.data })
+                    new apps[app](el, {app, ...args })
             })
         }
 
         // Default: Capture all link clicks. 
-        new GoogleTagManager(null, 'links')
+        new GoogleTagManager(null, {app: 'links', ...args})
     }, 1000)
 }
 

--- a/src/components/custom/layout/AppNavbar.jsx
+++ b/src/components/custom/layout/AppNavbar.jsx
@@ -15,7 +15,7 @@ const AppNavbar = ({ hidden, signoutHidden }) => {
         let url = APP_ROUTES.login
         if (isLoggedIn()) {
             logout()
-            url = getLogoutURL()
+            url = APP_ROUTES.logout //getLogoutURL()
         }
         window.location.replace(url)
     }

--- a/src/components/custom/layout/entity/ViewHeader.jsx
+++ b/src/components/custom/layout/entity/ViewHeader.jsx
@@ -1,0 +1,50 @@
+import React, { useContext } from 'react'
+import AppContext from '../../../../context/AppContext'
+import {Button} from 'react-bootstrap';
+import {FiletypeJson} from 'react-bootstrap-icons';
+import {displayBodyHeader} from "../../js/functions";
+import {ENTITIES} from "../../../../config/constants";
+import PropTypes from 'prop-types'
+
+const EntityViewHeaderButtons = ({entity, data, hasWritePrivilege}) => {
+    const {_t } = useContext(AppContext)
+    return (
+        <div>
+            {hasWritePrivilege &&
+                <Button aria-label={`Edit ${ENTITIES[entity]}`} className="ms-3 js-btn--edit" href={`/edit/${entity}?uuid=${data.uuid}`}
+                        variant="outline-primary rounded-0">{_t('Edit')}</Button>}{' '}
+                <Button target='_blank' aria-label={`View JSON of the ${ENTITIES[entity]}`} className="ms-3 js-btn--json" href={`/api/json/${entity}?uuid=${data.uuid}`}
+                    variant="outline-primary rounded-0"><FiletypeJson/></Button>
+        </div>
+    )
+}
+
+EntityViewHeaderButtons.propTypes = {
+    entity: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    hasWritePrivilege: PropTypes.bool.isRequired
+}
+
+function EntityViewHeader({entity, data, hasWritePrivilege}) {
+    const {_t } = useContext(AppContext)
+    return (
+        <div style={{width: '100%'}}>
+            <h4>{ENTITIES[entity]}</h4>
+            <h3>{data.sennet_id}</h3>
+            <div className="d-flex justify-content-between mb-2">
+                <div className="entity_subtitle link_with_icon">
+                    {displayBodyHeader(data.display_subtype)}
+                </div>
+                <EntityViewHeaderButtons data={data} entity={entity} hasWritePrivilege={hasWritePrivilege} />
+            </div>
+        </div>
+    )
+}
+
+EntityViewHeader.propTypes = {
+    entity: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
+    hasWritePrivilege: PropTypes.bool.isRequired
+}
+
+export {EntityViewHeader, EntityViewHeaderButtons}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -4,6 +4,7 @@ import { goToSearch } from '../components/custom/js/functions'
 import { getCookie, deleteCookie, setCookie } from 'cookies-next'
 import log from 'loglevel'
 import { get_read_write_privileges } from '../lib/services'
+import {deleteCookies} from "../lib/auth";
 
 const AppContext = createContext()
 
@@ -45,7 +46,10 @@ export const AppProvider = ({ children }) => {
             .then((read_write_privileges) => {
                 if (read_write_privileges.read_privs === true) {
                     setCookie(authKey, true)
-                    console.log('Author', hasAuthenticationCookie())
+                    if (router.query.info) {
+                        const {email, globus_id} = JSON.parse(router.query.info)
+                        setCookie('user', {email, globus_id})
+                    }
                     // Redirect to home page without query string
                     goToSearch()
                 } else {
@@ -61,9 +65,7 @@ export const AppProvider = ({ children }) => {
     }
 
     const logout = () => {
-        setCookie(authKey, false)
-        deleteCookie('groups_token')
-        deleteCookie('info')
+        deleteCookies()
     }
 
     // TODO: change to handle locale

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,0 +1,8 @@
+import {deleteCookie, setCookie} from "cookies-next";
+
+export function deleteCookies() {
+    setCookie('isAuthenticated', false)
+    deleteCookie('groups_token')
+    deleteCookie('info')
+    deleteCookie('user')
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,25 +4,25 @@ import ErrorBoundary from '../components/custom/error/ErrorBoundary'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { useIdleTimer } from 'react-idle-timer'
-import { deleteCookie, setCookie } from 'cookies-next'
+import {deleteCookie, getCookie, setCookie} from 'cookies-next'
 import { getIngestEndPoint, IDLE_TIMEOUT } from '../config/config'
 import useGoogleTagManager from '../hooks/useGoogleTagManager'
 import addons from "../components/custom/js/addons/addons"
 import { AppProvider } from '../context/AppContext'
-import { ORGAN_TYPES } from '../config/constants'
+import {ENTITIES, ORGAN_TYPES} from '../config/constants'
+import {deleteCookies} from "../lib/auth";
 
 function MyApp({ Component, pageProps }) {
     const router = useRouter()
     useGoogleTagManager()
 
     useEffect(() =>{
-        addons('init', {data: {facets: ORGAN_TYPES}})
+        const user = getCookie('user')
+        addons('init', {data: {facets: ORGAN_TYPES, user}, router, entities: ENTITIES})
     }, [])
 
     const onIdle = () => {
-        setCookie('isAuthenticated', false)
-        deleteCookie('groups_token')
-        deleteCookie('info')
+        deleteCookies()
         // Call Ingest API logout to revoke token
         fetch(getIngestEndPoint() + 'logout').then()
         router.push('/')

--- a/src/pages/dataset.jsx
+++ b/src/pages/dataset.jsx
@@ -1,8 +1,7 @@
 import React, {useContext, useEffect, useState} from "react";
 import {useRouter} from 'next/router';
 import 'bootstrap/dist/css/bootstrap.css';
-import {Button} from 'react-bootstrap';
-import {BoxArrowUpRight, CircleFill, FiletypeJson} from 'react-bootstrap-icons';
+import {BoxArrowUpRight, CircleFill} from 'react-bootstrap-icons';
 import {Layout} from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import Description from "../components/custom/entities/sample/Description";
@@ -21,6 +20,8 @@ import Files from "../components/custom/entities/dataset/Files";
 import Spinner from "../components/custom/Spinner";
 import AppContext from "../context/AppContext";
 import Alert from "../components/custom/Alert";
+import {EntityViewHeaderButtons} from "../components/custom/layout/entity/ViewHeader";
+import {ENTITIES} from "../config/constants";
 
 function ViewDataset() {
     const router = useRouter()
@@ -187,11 +188,7 @@ function ViewDataset() {
                                         |
                                         {/*TODO: Add some access level?  | {data.mapped_data_access_level} Access*/}
 
-                                        {hasWritePrivilege &&
-                                            <Button className="ms-3" href={`/edit/dataset?uuid=${data.uuid}`}
-                                                    variant="outline-primary rounded-0">Edit</Button>}{' '}
-                                        <Button className="ms-3" href={`/api/json/dataset?uuid=${data.uuid}`}
-                                                variant="outline-primary rounded-0"><FiletypeJson/></Button>
+                                        <EntityViewHeaderButtons data={data} entity={Object.keys(ENTITIES)[2]} hasWritePrivilege={hasWritePrivilege} />
                                     </div>
                                 </div>
                             </div>

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -272,7 +272,7 @@ export default function EditDataset() {
                                         <DataTypes values={values} data={data} onChange={onChange}/>
                                     }
 
-                                    <Button variant="outline-primary rounded-0" onClick={handleSubmit} disabled={disableSubmit}>
+                                    <Button variant="outline-primary rounded-0 js-btn--submit" onClick={handleSubmit} disabled={disableSubmit}>
                                         {_t('Submit')}
 
                                     </Button>

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -272,7 +272,7 @@ function EditSample() {
                                         onChange={onChange} text='A free text description of the specimen.' />
 
 
-                                    <Button variant="outline-primary rounded-0" onClick={handleSubmit} disabled={disableSubmit}>
+                                    <Button variant="outline-primary rounded-0 js-btn--submit" onClick={handleSubmit} disabled={disableSubmit}>
                                         {_t('Submit')}
 
                                     </Button>

--- a/src/pages/edit/source.jsx
+++ b/src/pages/edit/source.jsx
@@ -167,7 +167,7 @@ function EditSource() {
                                     <EntityFormGroup label='Description' type='textarea' controlId='description' value={data.description} 
                                         onChange={onChange} text='Free text field to enter a description of the source.' />
 
-                                    <Button variant="outline-primary rounded-0" onClick={handleSubmit}
+                                    <Button variant="outline-primary rounded-0 js-btn--submit" onClick={handleSubmit}
                                             disabled={disableSubmit}>
                                         {_t('Submit')}
                                     </Button>

--- a/src/pages/sample.jsx
+++ b/src/pages/sample.jsx
@@ -1,8 +1,6 @@
 import React, {useContext, useEffect, useState} from "react";
 import {useRouter} from 'next/router';
 import 'bootstrap/dist/css/bootstrap.css';
-import {Button} from 'react-bootstrap';
-import {FiletypeJson} from 'react-bootstrap-icons';
 import {Layout} from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import Description from "../components/custom/entities/sample/Description";
@@ -20,6 +18,8 @@ import Header from "../components/custom/layout/Header";
 import Spinner from "../components/custom/Spinner";
 import AppContext from "../context/AppContext";
 import Alert from "../components/custom/Alert";
+import {ENTITIES} from "../config/constants";
+import {EntityViewHeader} from "../components/custom/layout/entity/ViewHeader";
 
 function ViewSample() {
     const router = useRouter()
@@ -144,23 +144,7 @@ function ViewSample() {
                         }
 
                         bodyHeader={
-                            <div style={{width: '100%'}}>
-                                <h4>Sample</h4>
-                                <h3>{data.sennet_id}</h3>
-                                <div className="d-flex justify-content-between mb-2">
-                                    <div className="entity_subtitle link_with_icon">
-                                        {displayBodyHeader(data.display_subtype)}
-                                    </div>
-                                    <div>
-                                        {hasWritePrivilege &&
-                                            <Button className="ms-3" href={`/edit/sample?uuid=${data.uuid}`}
-                                                    variant="outline-primary rounded-0">Edit</Button>}{' '}
-                                        <Button className="ms-3" href={`/api/json/sample?uuid=${data.uuid}`}
-                                                variant="outline-primary rounded-0"><FiletypeJson/></Button>
-                                    </div>
-                                </div>
-
-                            </div>
+                            <EntityViewHeader data={data} entity={Object.keys(ENTITIES)[1]} hasWritePrivilege={hasWritePrivilege} />
                         }
 
                         bodyContent={

--- a/src/pages/source.jsx
+++ b/src/pages/source.jsx
@@ -1,8 +1,6 @@
 import React, {useContext, useEffect, useState} from "react";
 import {useRouter} from 'next/router';
 import 'bootstrap/dist/css/bootstrap.css';
-import {Button} from 'react-bootstrap';
-import {FiletypeJson} from 'react-bootstrap-icons';
 import {Layout} from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import Description from "../components/custom/entities/sample/Description";
@@ -20,6 +18,8 @@ import Header from "../components/custom/layout/Header";
 import Spinner from "../components/custom/Spinner";
 import AppContext from "../context/AppContext";
 import Alert from "../components/custom/Alert";
+import {EntityViewHeader} from "../components/custom/layout/entity/ViewHeader";
+import {ENTITIES} from "../config/constants";
 
 function ViewSource() {
     const router = useRouter()
@@ -122,26 +122,7 @@ function ViewSource() {
                         }
 
                         bodyHeader={
-                            <div style={{width: '100%'}}>
-                                <h4>Source</h4>
-                                <h3>{data.sennet_id}</h3>
-
-                                <div className="d-flex justify-content-between mb-2">
-                                    <div className="entity_subtitle link_with_icon">
-                                        {displayBodyHeader(data.source_type)}
-                                    </div>
-                                    <div>
-                                        {hasWritePrivilege &&
-                                            <Button className="ms-3" href={`/edit/source?uuid=${data.uuid}`}
-                                                    variant="outline-primary rounded-0">Edit</Button>}{' '}
-                                        <Button className="ms-3" href={`/api/json/source?uuid=${data.uuid}`}
-                                                variant="outline-primary rounded-0">
-                                            <FiletypeJson/>
-                                        </Button>
-                                    </div>
-                                </div>
-
-                            </div>
+                            <EntityViewHeader data={data} entity={Object.keys(ENTITIES)[0]} hasWritePrivilege={hasWritePrivilege} />
                         }
 
                         bodyContent={


### PR DESCRIPTION
This is in working order. 
Now tracking:

Event: `entity `
With properties: entity [Source|Sample|Dataset], uuid, path, action [view|edit]  ... 
Event: `cta`
With properties: action [login|submit|json], label, uuid ... 

All previous and new events now include `session` [true|false] and `person` (part of the user id as we aren't allowed by GA to track full emails) variables.

cc @shirey 
