### PR TITLE
Libpitt/provenance visuals 173

### DIFF
--- a/src/components/custom/entities/Provenance.jsx
+++ b/src/components/custom/entities/Provenance.jsx
@@ -25,14 +25,26 @@ function Provenance({ nodeData }) {
 
     const onCenterX = (ops) => {
         const w = canvas(ops).width()
-        return  ops.data.nodes.length > 7 ? w / 2 : w / 2.3
+        return  w / 2.4
+    }
+
+    const getTreeWidth = (ops) => {
+        const list = {}
+        let max = 3
+        for (let n of ops.data.stratify) {
+            let id = n.activityAsParent
+            list[id] = ++list[id] || 1
+            max = Math.max(list[id], max)
+        }
+        log.debug('Tree width', max)
+        return max
     }
 
     const onSvgSizing = (ops) => {
         let { margin } = ops.args
         const sz = {}
         sz.width = canvas(ops).width() - margin.right - margin.left
-        sz.height = 400 - margin.top - margin.bottom
+        sz.height = ops.options.minHeight * getTreeWidth(ops) - margin.top - margin.bottom
         return sz
     }
 
@@ -51,7 +63,7 @@ function Provenance({ nodeData }) {
             "Source": "#ffc255"
         },
         displayEdgeLabels: true,
-        minHeight: 200,
+        minHeight: 100,
         noStyles: true,
         selectorId: 'neo4j--page',
         callbacks: {
@@ -182,7 +194,7 @@ function Provenance({ nodeData }) {
                 {!loading && <Legend colorMap={{...options.colorMap, Edge: '#a5abb6'}} actionMap={actionMap} selectorId={options.selectorId}/>}
                 {loading && <Spinner/>}
                 <AppModal showModal={showModal} handleClose={handleModal} showCloseButton={true} showHomeButton={false} modalTitle='Provenance' modalSize='xl' className='modal-full'>
-                    {!loading && <ProvenanceUI options={{...options, selectorId: modalId }} data={treeData} />}
+                    {!loading && <ProvenanceUI options={{...options, selectorId: modalId, minHeight: 105 }} data={treeData} />}
                     {!loading && <Legend colorMap={{...options.colorMap, Edge: '#a5abb6'}} actionMap={actionMap} selectorId={modalId} />}
                 </AppModal>
             </div>

--- a/src/components/custom/entities/Provenance.jsx
+++ b/src/components/custom/entities/Provenance.jsx
@@ -30,7 +30,7 @@ function Provenance({ nodeData }) {
 
     const getTreeWidth = (ops) => {
         const list = {}
-        let max = 3
+        let max = 1
         for (let n of ops.data.stratify) {
             let id = n.activityAsParent
             list[id] = ++list[id] || 1
@@ -44,7 +44,8 @@ function Provenance({ nodeData }) {
         let { margin } = ops.args
         const sz = {}
         sz.width = canvas(ops).width() - margin.right - margin.left
-        sz.height = ops.options.minHeight * getTreeWidth(ops) - margin.top - margin.bottom
+        const treeWidth = getTreeWidth(ops)
+        sz.height = ops.options.minHeight * (treeWidth < 2 ? 3 : Math.max(treeWidth, 5) ) - margin.top - margin.bottom
         return sz
     }
 

--- a/src/components/custom/entities/Provenance.jsx
+++ b/src/components/custom/entities/Provenance.jsx
@@ -130,7 +130,7 @@ function Provenance({ nodeData }) {
             setLoading(false)
         }
 
-        if (token.length && url.length && itemId.length) {
+        if (url.length && itemId.length) {
             const graph = new GraphGeneric(graphOps)
             graph.service({ callback: handleResult, url: url.replace('{id}', itemId) })
         }

--- a/src/pages/dataset.jsx
+++ b/src/pages/dataset.jsx
@@ -119,7 +119,7 @@ function ViewDataset() {
                                                 className="sui-single-option-facet__link"
                                                 href="#Files">Files</a>
                                             </li>
-                                            {isLoggedIn() && <li className="sui-single-option-facet__item"><a
+                                            { <li className="sui-single-option-facet__item"><a
                                             className="sui-single-option-facet__link" href="#Provenance">Provenance</a>
                                             </li> }
                                             {data.immediate_ancestors &&
@@ -211,7 +211,7 @@ function ViewDataset() {
                                     <Files sennet_id={data.sennet_id}/>
 
                                     {/*Provenance*/}
-                                    {data && isLoggedIn() &&
+                                    {data &&
                                         <Provenance nodeData={data}/>
                                     }
 

--- a/src/pages/sample.jsx
+++ b/src/pages/sample.jsx
@@ -116,7 +116,7 @@ function ViewSample() {
                                                     Datasets</a>
                                                 </li>
                                             }
-                                            {isLoggedIn() && <li className="sui-single-option-facet__item"><a
+                                            { <li className="sui-single-option-facet__item"><a
                                             className="sui-single-option-facet__link" href="#Provenance">Provenance</a>
                                         </li>}
                                             {data.ancestors &&
@@ -166,7 +166,7 @@ function ViewSample() {
 
 
                                     {/*Provenance*/}
-                                    {data && isLoggedIn() &&
+                                    {data &&
                                     <Provenance nodeData={data}/>
                                     }
 

--- a/src/pages/source.jsx
+++ b/src/pages/source.jsx
@@ -104,7 +104,7 @@ function ViewSource() {
                                                     href="#Derived-Datasets">Derived</a>
                                                 </li>
                                             }
-                                            {isLoggedIn() && <li className="sui-single-option-facet__item"><a
+                                            { <li className="sui-single-option-facet__item"><a
                                             className="sui-single-option-facet__link" href="#Provenance">Provenance</a>
                                         </li>}
                                             {data.protocol_url &&
@@ -147,7 +147,7 @@ function ViewSource() {
                                     }
 
                                     {/*Provenance*/}
-                                    {data &&  isLoggedIn() &&
+                                    {data &&
                                         <Provenance nodeData={data}/>
                                     }
 


### PR DESCRIPTION
### Fixed: 
1. Make Provenance section public
2. Flip context such that root starts from source so generated depth values can be used to properly lay out node by levels
### Before:
![prov-Before](https://user-images.githubusercontent.com/115558393/206268900-2a8ec411-99ac-441d-9b27-a5dac2911293.png)

### After:
![prov-After](https://user-images.githubusercontent.com/115558393/206268897-01bb1314-27e5-496d-a031-79650eced630.png)

### Noted visual issue: 
Because we can end up with graph visuals, I have noted that edges may cross each other while trying to layout the graph as a tree. (Due to nodes having multiple parents.)
cc @shirey 
