### PR TITLE
Get the dataset ancestor search query values from entity-api instead …

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -23,7 +23,7 @@ export function getAuth() {
 export const nonSupportedRuiOrgans = ['AO', 'BD', 'BS', 'MU', 'OT']
 
 export function isOrganRuiSupported(organs) {
-    if(organs.length > 0) {
+    if (organs.length > 0) {
         const supported_organ = (organ) => !nonSupportedRuiOrgans.includes(organ);
 
         return organs.some(supported_organ)
@@ -319,19 +319,7 @@ export let ancestor_config = _.cloneDeep(config)
 ancestor_config['trackUrlState'] = false;
 
 export let valid_dataset_ancestor_config = _.cloneDeep(ancestor_config)
-valid_dataset_ancestor_config['searchQuery']['includeFilters'] = [{
-    keyword: "sample_category.keyword",
-    value: "section"
-}, {
-    keyword: "sample_category.keyword",
-    value: "suspension"
-}, {
-    keyword: "sample_category.keyword",
-    value: "block"
-}, {
-    keyword: "entity_type.keyword",
-    value: "Dataset"
-}]
+
 valid_dataset_ancestor_config['searchQuery']['disjunctiveFacets'] = ["group_name", "created_by_user_displayname"]
 
 export let exclude_dataset_config = _.cloneDeep(ancestor_config);

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -21,11 +21,11 @@ import Header from '../../components/custom/layout/Header'
 import AppContext from '../../context/AppContext'
 import EntityContext, {EntityProvider} from '../../context/EntityContext'
 import Spinner from '../../components/custom/Spinner'
-import {DATA_TYPES, ENTITIES, SAMPLE_CATEGORY} from '../../config/constants'
+import {DATA_TYPES, ENTITIES} from '../../config/constants'
 import EntityHeader from '../../components/custom/layout/entity/Header'
 import EntityFormGroup from '../../components/custom/layout/entity/FormGroup'
 import Alert from '../../components/custom/Alert'
-import {getEntityEndPoint} from "../../config/config";
+import {getEntityEndPoint, valid_dataset_ancestor_config} from "../../config/config";
 
 export default function EditDataset() {
     const {
@@ -46,6 +46,25 @@ export default function EditDataset() {
     const [ancestors, setAncestors] = useState(null)
     const [containsHumanGeneticSequences, setContainsHumanGeneticSequences] = useState(null)
     const [dataTypes, setDataTypes] = useState(null)
+
+    useEffect(() => {
+        async function fetchAncestorConstraints() {
+            const body = {
+                entity_type: 'dataset'
+            }
+            const requestOptions = {
+                method: 'POST',
+                headers: getHeaders(),
+                body: JSON.stringify(body)
+            }
+            const response = await fetch(getEntityEndPoint() + 'constraints?' + new URLSearchParams({relationship_direction: 'ancestors'}), requestOptions)
+            if (response.ok) {
+                valid_dataset_ancestor_config['searchQuery']['includeFilters'] = await response.json()
+            }
+        }
+
+        fetchAncestorConstraints()
+    }, [])
 
     useEffect(() => {
         const fetchDataTypes = async () => {


### PR DESCRIPTION
Get the dataset allowable ancestors from entity-api instead of hardcoding them. [Related PR](https://github.com/sennetconsortium/entity-api/pull/39)