### PR TITLE
Add AWS log driver to docker-compose.yml to send server logs to Cloud…

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,11 @@ services:
       - "../log:/usr/src/app/log"
     networks:
       - sennet_docker_network
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: us-east-1
+        awslogs-group: /aws/ec2/sennet-dev/portal-ui/next-server
 
 networks:
   # This is the network created by gateway to enable communicaton between multiple docker-compose projects

--- a/src/pages/api/find.js
+++ b/src/pages/api/find.js
@@ -1,12 +1,10 @@
 import {simple_query_builder} from "search-ui/lib/search-tools";
 import {getIndex, getSearchEndPoint} from "../../config/config";
-import log from "loglevel";
 
 // a mock service to return some data
-export default function handler(req, res) {
+export default async function handler(req, res) {
     var error_messages = [{error: "Only support GET/POST"}, {error: "UUID Not found, please check for the correct id"}]
-
-    log.info("FIND API...")
+    console.log("FIND API...")
 
     // only allow POST
     if (req.method === "GET" || req.method === "POST") {
@@ -17,7 +15,8 @@ export default function handler(req, res) {
         if (uuid) {
             // need to convert into a ES ready query
             let queryBody = simple_query_builder("uuid", uuid)
-            log.info('QUERY', JSON.stringify(queryBody))
+            console.log('QUERY')
+            console.dir(queryBody, {depth: null})
             var myHeaders = new Headers();
             if(req.headers.authorization !== undefined) {
                 myHeaders.append("Authorization", req.headers.authorization);
@@ -31,13 +30,14 @@ export default function handler(req, res) {
             };
             // request("POST", "search", queryBody, getAuth(), getSearchEndPoint()).then(json =>
             //       //adaptResponse(json, this.indexName)
-            //       log.info(json)
+            //       console.log(json)
             //       //res.status(200).json(json)
             //     )
-            fetch(getSearchEndPoint() + getIndex() + "/search", requestOptions)
+            await fetch(getSearchEndPoint() + getIndex() + "/search", requestOptions)
                 .then(response => response.json())
                 .then(result => {
-                    log.info(result)
+                    console.log('SEARCH API RESPONSE BODY')
+                    console.dir(result, {depth: null})
 
                     if (result.hasOwnProperty("error")) {
                         res.status(401).json(result)
@@ -52,7 +52,7 @@ export default function handler(req, res) {
                     }
                 })
                 .catch(error => {
-                    log.info(error)
+                    console.log(error)
                     res.status(500).json(error)
                 });
         } else {

--- a/src/pages/api/json/[entity].js
+++ b/src/pages/api/json/[entity].js
@@ -1,8 +1,8 @@
 import {getRootURL} from "../../../config/config";
-import log from "loglevel";
 import {getCookie, hasCookie} from "cookies-next";
 
 export default async function handler(req, res) {
+    console.log('JSON API STARTING...')
     const uuid = req.query.uuid
     let auth = req.headers.authorization
     let myHeaders = new Headers();
@@ -17,11 +17,11 @@ export default async function handler(req, res) {
         method: 'GET',
         headers: myHeaders
     }
-    log.info('sample: getting data...', uuid)
+    console.log('sample: getting data...', uuid)
     await fetch(getRootURL() + "api/find?uuid=" + uuid, requestOptions)
         .then(response => response.json())
         .then(result => {
-            log.debug(result)
+            console.log(result)
 
             if (result.hasOwnProperty("error")) {
                 res.status(401).json(result)
@@ -29,7 +29,7 @@ export default async function handler(req, res) {
                 res.status(200).json(result)
             }
         }).catch(error => {
-            log.error(error)
+            console.error(error)
             res.status(500).json(error)
         });
 }


### PR DESCRIPTION
I configured the `docker-compose.yml` to use the AWS logs driver. This sends stdout from the docker container to the AWS Cloudwatch service. Each log stream is named after the container ID. A new log stream will be created when the container is restarted. You have to use `console.log` in the `pages/api/` handler functions for the messages to go to Cloudwatch, not `log from loglevel`.

Also resolved a warning `API resolved without sending the response for /api/find?uuid=... this may result in stalled requests.` By using async/await