### PR TITLE
Use an environment variable for the cloudwatch log group

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There are a few configurable environment variables to keep in mind:
 
 - `HOST_UID`: the user id on the host machine to be mapped to the container. Default to 1000 if not set or null.
 - `HOST_GID`: the user's group id on the host machine to be mapped to the container. Default to 1000 if not set or null.
+- `PORTAL_UI_CLOUDWATCH_LOG_GROUP='/aws/ec2/sennet-dev/portal-ui/next-server'`: The Cloudwatch log group that saves the nodejs/next-js server logs
 
 ```
 cd docker
@@ -63,4 +64,7 @@ cd docker
 docker pull hubmap/portal-ui:1.0.0 (replace with the actual released version number)
 ./docker-deployment.sh [start|stop|down]
 ```
+Environment vars
+- `PORTAL_UI_CLOUDWATCH_LOG_GROUP='/aws/ec2/sennet-prod/portal-ui/next-server'`: The Cloudwatch log group that saves the nodejs/next-js server logs
+
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,9 +30,9 @@ services:
       driver: awslogs
       options:
         awslogs-region: us-east-1
-        awslogs-group: /aws/ec2/sennet-dev/portal-ui/next-server
+        awslogs-group: ${PORTAL_UI_CLOUDWATCH_LOG_GROUP:?err}
 
 networks:
-  # This is the network created by gateway to enable communicaton between multiple docker-compose projects
+  # This is the network created by gateway to enable communication between multiple docker-compose projects
   sennet_docker_network:
     external: true


### PR DESCRIPTION
Replace the hard-coded log group with an environment variable.

I added `PORTAL_UI_CLOUDWATCH_LOG_GROUP="/aws/ec2/sennet-dev/portal-ui/next-server"` to the codcc user's `.bashrc` on the DEV ec2 instance. We will need to add this to the PROD ec2 instance as well.