### PR TITLE
Update event listener

### DIFF
--- a/src/components/custom/js/addons/Facets.js
+++ b/src/components/custom/js/addons/Facets.js
@@ -21,6 +21,9 @@ class Facets extends Addon {
     }
 
     events() {
+        $(document).on('DOMSubtreeModified', ((e) => {
+            this.formatFilters(0)
+        }).bind(this))
 
         this.onKeydownEnter(`${this.sel.title},${this.sel.select}`)
 
@@ -28,16 +31,12 @@ class Facets extends Addon {
             this.currentTarget(e).parent().trigger('click')
             this.currentTarget(e).focus()
         }).bind(this))
-
-        this.el.on('click', `${this.sel.wrapper},${this.sel.more}`, ((e) => {
-            this.formatFilters()
-        }).bind(this))
     }
 
     /**
      * Find elements to be formatted
      */
-    formatFilters() {
+    formatFilters(time = 150) {
 
         //Get some delay by triggering the web api
         let st = setTimeout((() => {
@@ -51,7 +50,7 @@ class Facets extends Addon {
 
             }).bind(this))
 
-        }).bind(this), 250)
+        }).bind(this), time)
     }
 
     /**

--- a/src/components/custom/js/addons/Facets.js
+++ b/src/components/custom/js/addons/Facets.js
@@ -21,7 +21,7 @@ class Facets extends Addon {
     }
 
     events() {
-        $(document).on('DOMSubtreeModified', ((e) => {
+        this.el.on('DOMSubtreeModified', ((e) => {
             this.formatFilters(0)
         }).bind(this))
 


### PR DESCRIPTION
Hey @maxsibilla 

Can you check this one out. I updated the event to listen for dom modifications rather than after the click event on the `+ More` link element, that way properly waiting for `search-ui` to complete its dom modifications before the formatter gets run. Initially just assumed the `search-ui` would have been done modifications by `~250ms` as was in the `setTimeout` but the completion time of the `search-ui` varies thus resulting in this bug.

Note: We will still have the onload delay though...