### PR TITLE
Allow for auto revalidation of metadata

### DIFF
--- a/src/components/custom/edit/MetadataUpload.jsx
+++ b/src/components/custom/edit/MetadataUpload.jsx
@@ -54,7 +54,11 @@ function MetadataUpload({ setMetadata, entity, subType }) {
 
     useEffect(()=> {
         if (file && rerun !== subType) {
+            setError(true)
             setRerun(subType)
+            setSuccess(false)
+            setMetadata({})
+            handleUpload(null)
         } else {
             setRerun(null)
         }
@@ -105,7 +109,7 @@ function MetadataUpload({ setMetadata, entity, subType }) {
 
     const handleUpload = async (e) => {
         try {
-            const upload = e.currentTarget.files ? e.currentTarget.files[0] : file
+            const upload = e && e.currentTarget.files ? e.currentTarget.files[0] : file
             if (!upload) return
             log.debug('Metadata', file)
             setRerun(null)
@@ -122,7 +126,8 @@ function MetadataUpload({ setMetadata, entity, subType }) {
             $('[type=file]').val(null)
             if (details.code !== 200) {
                 setError(details.description)
-                setFileStatus(details.name)
+                const uploadName = upload.name.length > 12 ? upload.name.substr(0, 12) + '...' : upload.name
+                setFileStatus(`${details.name}: ${uploadName}`)
                 setSuccess(false)
                 const result = getErrorList(details)
                 if (isUnacceptable(details.code)) {
@@ -190,12 +195,11 @@ function MetadataUpload({ setMetadata, entity, subType }) {
                     {error && <XCircleFill color='#842029' />}
                     {success && <CheckCircleFill color='#0d6efd' />}
                     <small role={validationError ? 'button' : null} onClick={downloadDetails} title={`${validationError ? 'Download error report' : ''}`}>
-                        {fileStatus} {validationError && <Download />}
+                        <span className={'c-metadataUpload__fileStatus'}>{fileStatus}</span> {validationError && <Download />}
                         {isValidating && <span className="spinner spinner-border ic alert alert-info"></span>}
                     </small>
-                    {rerun && <span role='button' onClick={handleUpload} title='Rerun validation' className='ic rerun'> <ArrowRepeat size={12} /></span>}
                 </span>
-                {error &&  <div className='c-metadataUpload__table table-responsive has-error'>
+                {error && table.data && <div className='c-metadataUpload__table table-responsive has-error'>
                     <DataTable
                         columns={table.columns}
                         data={table.data}

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -299,7 +299,7 @@ function EditSample() {
             let json = cleanJson(values);
             let uuid = data.uuid
 
-            if(!_.isEmpty(metadata)) {
+            if(!_.isEmpty(metadata) && supportsMetadata()) {
                 values["metadata"] = metadata.metadata
                 values["pathname"] = metadata.pathname
             }
@@ -335,6 +335,10 @@ function EditSample() {
         setValidated(true);
     };
 
+    const supportsMetadata = () => {
+        {/*# TODO: Use ontology*/}
+        return values.sample_category !== 'organ'
+    }
 
     if (isAuthorizing() || isUnauthorized()) {
         return (
@@ -449,8 +453,7 @@ function EditSample() {
                                                        values={values}
                                                        setValues={setValues}/>
 
-                                    {/*# TODO: Use ontology*/}
-                                    { values.sample_category && values.sample_category !== 'organ' && <MetadataUpload setMetadata={setMetadata} entity={ENTITIES.sample} subType={values.sample_category}  /> }
+                                    { values.sample_category && supportsMetadata() && <MetadataUpload setMetadata={setMetadata} entity={ENTITIES.sample} subType={values.sample_category}  /> }
                                     <div className={'d-flex flex-row-reverse'}>
                                         <Button variant="outline-primary rounded-0 js-btn--submit" onClick={handleSubmit}
                                                 disabled={disableSubmit}>

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -299,9 +299,13 @@ function EditSample() {
             let json = cleanJson(values);
             let uuid = data.uuid
 
-            if(!_.isEmpty(metadata) && supportsMetadata()) {
-                values["metadata"] = metadata.metadata
-                values["pathname"] = metadata.pathname
+            if(!_.isEmpty(metadata)) {
+                if (supportsMetadata()) {
+                    values["metadata"] = metadata.metadata
+                    values["pathname"] = metadata.pathname
+                } else {
+                    delete values["metadata"]
+                }
             }
 
             await update_create_entity(uuid, json, editMode, ENTITIES.sample, router).then((response) => {

--- a/src/pages/edit/source.jsx
+++ b/src/pages/edit/source.jsx
@@ -114,7 +114,7 @@ function EditSource() {
             let json = cleanJson(values);
             let uuid = data.uuid
 
-            if(!_.isEmpty(metadata)) {
+            if(!_.isEmpty(metadata) && supportsMetadata()) {
                 values["metadata"] = metadata.metadata
                 values["pathname"] = metadata.pathname
             }
@@ -137,6 +137,10 @@ function EditSource() {
         setValidated(true);
     };
 
+    const supportsMetadata = () => {
+        {/*# TODO: Use ontology*/}
+        return values.source_type === 'Human'
+    }
 
     if (isAuthorizing() || isUnauthorized()) {
         return (
@@ -198,8 +202,7 @@ function EditSource() {
                                                    imageByteArray={imageByteArray}
                                                    setImageByteArray={setImageByteArray}/>
 
-                                    {/*# TODO: Use ontology*/}
-                                    { values && values.source_type === 'Human' && <MetadataUpload setMetadata={setMetadata} entity={ENTITIES.source} />}
+                                    { values && supportsMetadata() && <MetadataUpload setMetadata={setMetadata} entity={ENTITIES.source} />}
                                     <div className={'d-flex flex-row-reverse'}>
                                         <Button variant="outline-primary rounded-0 js-btn--submit " onClick={handleSubmit}
                                                 disabled={disableSubmit}>

--- a/src/pages/edit/source.jsx
+++ b/src/pages/edit/source.jsx
@@ -114,9 +114,13 @@ function EditSource() {
             let json = cleanJson(values);
             let uuid = data.uuid
 
-            if(!_.isEmpty(metadata) && supportsMetadata()) {
-                values["metadata"] = metadata.metadata
-                values["pathname"] = metadata.pathname
+            if(!_.isEmpty(metadata)) {
+                if (supportsMetadata()) {
+                    values["metadata"] = metadata.metadata
+                    values["pathname"] = metadata.pathname
+                } else {
+                    delete values["metadata"]
+                }
             }
 
             await update_create_entity(uuid, json, editMode, ENTITIES.source, router).then((response) => {

--- a/src/sass/components/metadaUpload.scss
+++ b/src/sass/components/metadaUpload.scss
@@ -6,6 +6,14 @@
     width: 100%;
   }
 
+  &__fileStatus {
+    overflow: hidden;
+    white-space: nowrap;
+    display: inline-flex;
+    max-width: 200px;
+    text-overflow: ellipsis;
+  }
+
   &__meta {
     font-size: 16px;
     padding-top: 10px;


### PR DESCRIPTION
Change log:
1. Allow for automatic revalidation when user switches sub type values.
2. Check that metadata and sub type value set are supported, delete otherwise for older entries