### PR TITLE
Avoid multiple jsonp calls that cause cypress test breaks

### DIFF
--- a/src/components/custom/js/functions.js
+++ b/src/components/custom/js/functions.js
@@ -50,14 +50,19 @@ export async function fetchProtocol(protocolUrl) {
 export async function fetchProtocolView(protocolUrl) {
     if (!protocolUrl) return null
     let uri = getClickableLink(protocolUrl)
-    let result = await fetchJsonp(uri, {
-        timeout: 2000,
-    }).then(function(json) {
-        return true
-    }).catch(function(resp) {
-        return resp.message.contains('timed out')
-    })
-    return {ok: result}
+    try {
+        let result = await fetchJsonp(uri, {
+            timeout: 2000,
+        }).then(function(json) {
+            return true
+        }).catch(function(resp) {
+            return resp.message.contains('timed out')
+        })
+        return {ok: result}
+    } catch (e) {
+        console.error(e)
+        return {ok: false}
+    }
 }
 
 export async function fetchProtocols(protocolUrl) {

--- a/src/components/custom/layout/entity/FormGroup.jsx
+++ b/src/components/custom/layout/entity/FormGroup.jsx
@@ -6,7 +6,7 @@ import AppContext from '../../../../context/AppContext'
 import SenNetPopover from "../../../SenNetPopover";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 
-function EntityFormGroup({ controlId, label, text, onChange, value, type, placeholder, isRequired, pattern, popoverTrigger, className, warningText }) {
+function EntityFormGroup({ controlId, label, text, onChange, value, type, placeholder, isRequired, pattern, popoverTrigger, className, warningText, onBlur }) {
   const {_t } = useContext(AppContext)
   const isTextarea = (type === 'textarea')
 
@@ -22,9 +22,11 @@ function EntityFormGroup({ controlId, label, text, onChange, value, type, placeh
             </Form.Label>
             {!isTextarea && <Form.Control type={type}  defaultValue={value} placeholder={_t(placeholder)} required={isRequired}
                         pattern={pattern}
+                        onBlur={onBlur ? (e => onBlur(e, e.target.id, e.target.value)) : undefined}
                         onChange={e => onChange(e, e.target.id, e.target.value)} /> }
 
             {isTextarea && <Form.Control as={type} rows={4} defaultValue={value}
+                        onBlur={onBlur ? (e => onBlur(e, e.target.id, e.target.value)) : undefined}
                         onChange={e => onChange(e, e.target.id, e.target.value)} /> }
 
             {(className && className.indexOf('warning') !== -1) && <div className={'warning-icon-trigger'}>

--- a/src/context/EntityContext.jsx
+++ b/src/context/EntityContext.jsx
@@ -135,16 +135,16 @@ export const EntityProvider = ({ children }) => {
         let note;
         switch (noteKey) {
             case 0:
-                note = <>Metadata for this <code>{entity}</code> exists. </>
+                note = <span key={'md-0'}>Metadata for this <code>{entity}</code> exists. </span>
                 break
             case 1:
-                note = <>You may view it via <a target='_blank' className={'js-btn--json lnk--ic'} href={`/api/json/${entity.toLowerCase()}?uuid=${data.uuid}`}> the full entity JSON  <BoxArrowUpRight/></a>.</>
+                note = <span key={'md-1'}>You may view it via <a target='_blank' className={'js-btn--json lnk--ic'} href={`/api/json/${entity.toLowerCase()}?uuid=${data.uuid}`}> the full entity JSON  <BoxArrowUpRight/></a>.</span>
                 break
             case 2:
                 let prop = `${entity.toLowerCase()}_${field}`
                 let val = data[prop]
                 val = val[0].toUpperCase() + val.slice(1)
-                note =  <>Changing the <code>{entity}</code> {field} will result in loss of this metadata and cannot be undone once submitted. <br /> Please revert back to <span role={'button'} onClick={() => window.location = `#${prop}`}><code>{entity}</code> {field}</span> <code>{val}</code> to keep current metadata.</>
+                note =  <span key={'md-2'}>Changing the <code>{entity}</code> {field} will result in loss of this metadata and cannot be undone once submitted. <br /> Please revert back to <span role={'button'} onClick={() => window.location = `#${prop}`}><code>{entity}</code> {field}</span> <code>{val}</code> to keep current metadata.</span>
                 break
             default:
                 note = <></>
@@ -181,7 +181,7 @@ export const EntityProvider = ({ children }) => {
             const verb = isEditMode() ? 'Updated' : 'Registered'
             setHasSubmissionError(false)
             let body = []
-            setModalTitle(<span>{successIcon()}<span className={'title-text'} > {entity} {verb}</span></span>)
+            setModalTitle(<span key='title-0'>{successIcon()}<span key='title-1' className={'title-text'} > {entity} {verb}</span></span>)
             body.push(<span key='bdy-1'>{_t(`Your ${entity} was ${verb.toLocaleLowerCase()}`)}. <br /></span>)
             body.push(<span key='bdy-2'><strong>{_t(typeHeader)}:</strong> {type}<br /></span>)
             body.push(<span key='bdy-3'><strong>{_t('Group Name')}:</strong> {response.group_name}<br /></span>)

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -202,12 +202,14 @@ function EditSample() {
         // use a callback to find the field in the value list and update it
         onChange(e, fieldId, value)
 
-        if (fieldId === 'protocol_url') {
-            checkProtocolUrl(value)
-        }
-
         if (fieldId === 'direct_ancestor_uuid') {
             resetSampleCategory(e)
+        }
+    };
+
+    const _onBlur = (e, fieldId, value) => {
+        if (fieldId === 'protocol_url') {
+            checkProtocolUrl(value)
         }
     };
 
@@ -360,8 +362,7 @@ function EditSample() {
     }
 
     const metadataNote = () => {
-        {/*# TODO:  1. Update copy text and mailto, format. 2. Use ontology*/}
-        if (isEditMode() && values.metadata) {
+        if (isEditMode() && (values.metadata && Object.values(values.metadata).length)) {
             let text = []
             text.push(getMetadataNote(cache.entities.sample, 0))
             if (data.sample_category === values.sample_category) {
@@ -463,6 +464,7 @@ function EditSample() {
                                                      warningText={<>The supplied protocols.io DOI URL, formatting is correct but does not resolve. This will need to be corrected for any <code>Dataset</code> submission that uses this entity as an ancestor.</>}
                                                      popoverTrigger={SenPopoverOptions.triggers.hoverOnClickOff}
                                                      onChange={_onChange}
+                                                     onBlur={_onBlur}
                                                      text={<span>The protocol used when procuring or preparing the tissue. This must be provided as a protocols.io DOI URL see: <a
                                                          href="https://www.protocols.io/." target='_blank'
                                                          className='lnk--ic'>https://www.protocols.io/ <BoxArrowUpRight/></a>.</span>}/>

--- a/src/pages/edit/source.jsx
+++ b/src/pages/edit/source.jsx
@@ -185,10 +185,7 @@ function EditSource() {
     }
 
 
-    const _onChange = (e, fieldId, value) => {
-        // log.debug('onChange', fieldId, value)
-        // use a callback to find the field in the value list and update it
-        onChange(e, fieldId, value)
+    const _onBlur = (e, fieldId, value) => {
 
         if (fieldId === 'protocol_url') {
             checkProtocolUrl(value)
@@ -248,7 +245,7 @@ function EditSource() {
                                         controlId='protocol_url' value={data.protocol_url} isRequired={true} pattern={getDOIPattern()}
                                                      className={warningClasses.protocol_url}
                                                      warningText={<>The supplied protocols.io DOI URL, formatting is correct but does not resolve. This will need to be corrected for any <code>Dataset</code> submission that uses this entity as an ancestor.</>}
-                                                     onChange={_onChange} text={<span>The protocol used for <code>Source</code> selection including any inclusion or exclusion criteria. This must  be provided  as a protocols.io DOI see: <a href="https://www.protocols.io/." target='_blank' className='lnk--ic'>https://www.protocols.io/ <BoxArrowUpRight/></a>.</span>} />
+                                                     onChange={onChange} onBlur={_onBlur} text={<span>The protocol used for <code>Source</code> selection including any inclusion or exclusion criteria. This must  be provided  as a protocols.io DOI see: <a href="https://www.protocols.io/." target='_blank' className='lnk--ic'>https://www.protocols.io/ <BoxArrowUpRight/></a>.</span>} />
 
                                     {/*/!*Description*!/*/}
                                     <EntityFormGroup label='Lab Notes' type='textarea' controlId='description' value={data.description}


### PR DESCRIPTION
Change log:
1. Use onBlur event handler to avoid multiple jsonp requests (cypress breaks otherwise)
2. Fix issue with key prop missing