### PR TITLE
Libpitt/859 cookieshare

### DIFF
--- a/src/components/custom/layout/AppNavbar.jsx
+++ b/src/components/custom/layout/AppNavbar.jsx
@@ -52,7 +52,7 @@ const AppNavbar = ({hidden, signoutHidden}) => {
                         <NavDropdown
                             active={false}
                             variant={'primary'}
-                            hidden={hidden}
+                            hidden={hidden || !isLoggedIn()}
                             title={_t("Register entity")}
                             id="nav-dropdown"
                         >
@@ -84,7 +84,7 @@ const AppNavbar = ({hidden, signoutHidden}) => {
                         <NavDropdown
                             active={false}
                             variant={'primary'}
-                            hidden={hidden}
+                            hidden={hidden || !isLoggedIn()}
                             title="Upload metadata"
                             id="nav-dropdown--bulkMetadata">
                             {Object.keys(supportedMetadata()).map((entity, key) => (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -31,6 +31,15 @@ export const AppProvider = ({ cache, children }) => {
             setLocalItemWithExpiry(pageKey, router.asPath, 600000)
         }
 
+        let info = getCookie('info')
+        if (info) {
+            info = atob(info)
+            setCookie(
+                'groups_token',
+                JSON.parse(info).groups_token
+            )
+        }
+
         get_read_write_privileges()
             .then((response) => {
                 if (response) {

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -59,7 +59,7 @@ export default function EditDataset() {
         getSampleEntityConstraints,
         buildConstraint, successIcon, errIcon, getCancelBtn
     } = useContext(EntityContext)
-    const {_t, cache, adminGroup} = useContext(AppContext)
+    const {_t, cache, adminGroup, isLoggedIn} = useContext(AppContext)
     const router = useRouter()
     const [ancestors, setAncestors] = useState(null)
     const [containsHumanGeneticSequences, setContainsHumanGeneticSequences] = useState(null)
@@ -356,9 +356,9 @@ export default function EditDataset() {
 
 
 
-    if (isAuthorizing() || isUnauthorized()) {
+    if (isAuthorizing() || isUnauthorized() || !isLoggedIn()) {
         return (
-            isUnauthorized() ? <Unauthorized/> : <Spinner/>
+            isUnauthorized() || !isLoggedIn() ? <Unauthorized/> : <Spinner/>
         )
     } else {
 

--- a/src/pages/edit/publication.jsx
+++ b/src/pages/edit/publication.jsx
@@ -45,7 +45,7 @@ export default function EditPublication() {
         selectedUserWriteGroupUuid,
         disableSubmit, setDisableSubmit, getCancelBtn
     } = useContext(EntityContext)
-    const {_t, cache} = useContext(AppContext)
+    const {_t, cache, isLoggedIn} = useContext(AppContext)
     const router = useRouter()
     const [ancestors, setAncestors] = useState(null)
     const [publicationStatus, setPublicationStatus] = useState(null)
@@ -198,9 +198,9 @@ export default function EditPublication() {
         setPublicationStatus(false)
     }
 
-    if (isAuthorizing() || isUnauthorized()) {
+    if (isAuthorizing() || isUnauthorized() || !isLoggedIn()) {
         return (
-            isUnauthorized() ? <Unauthorized/> : <Spinner/>
+            isUnauthorized() || !isLoggedIn() ? <Unauthorized/> : <Spinner/>
         )
     } else {
 

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -56,7 +56,7 @@ function EditSample() {
         checkMetadata, getMetadataNote, checkProtocolUrl,
         warningClasses, getCancelBtn
     } = useContext(EntityContext)
-    const {_t, cache, filterImageFilesToAdd} = useContext(AppContext)
+    const {_t, cache, filterImageFilesToAdd, isLoggedIn} = useContext(AppContext)
     const router = useRouter()
     const [source, setSource] = useState(null)
     const [sourceId, setSourceId] = useState(null)
@@ -378,9 +378,9 @@ function EditSample() {
         }
     }
 
-    if (isAuthorizing() || isUnauthorized()) {
+    if (isAuthorizing() || isUnauthorized() || !isLoggedIn()) {
         return (
-            isUnauthorized() ? <Unauthorized/> : <Spinner/>
+            isUnauthorized() || !isLoggedIn() ? <Unauthorized/> : <Spinner/>
         )
     } else {
         return (

--- a/src/pages/edit/source.jsx
+++ b/src/pages/edit/source.jsx
@@ -40,7 +40,7 @@ function EditSource() {
         dataAccessPublic, setDataAccessPublic,
         metadata, setMetadata, checkMetadata, getMetadataNote, checkProtocolUrl,
         warningClasses, getCancelBtn } = useContext(EntityContext)
-    const { _t, filterImageFilesToAdd, cache } = useContext(AppContext)
+    const { _t, filterImageFilesToAdd, cache, isLoggedIn } = useContext(AppContext)
 
     const router = useRouter()
     const [source, setSource] = useState(null)
@@ -209,9 +209,9 @@ function EditSource() {
         }
     };
 
-    if (isAuthorizing() || isUnauthorized()) {
+    if (isAuthorizing() || isUnauthorized() || !isLoggedIn()) {
         return (
-            isUnauthorized() ? <Unauthorized /> : <Spinner />
+            isUnauthorized() || !isLoggedIn() ? <Unauthorized /> : <Spinner />
         )
     } else {
         console.log(values)


### PR DESCRIPTION
Change log:
1. Add `info` cookie logic to `AppContext` to facilitate "auto log in", that is setting up of `isAuthenticated` and `groups_token` cookies. 
2. Must also check `isLoggedIn` state to avoid showing edit pages, auth menu items since `info` cookie can be controlled on other subdomain.