### PR TITLE
Adding explicit SameSite=Lax to cookies

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -49,7 +49,8 @@ export const AppProvider = ({ cache, children }) => {
             info = atob(info)
             setCookie(
                 'groups_token',
-                JSON.parse(info).groups_token
+                JSON.parse(info).groups_token,
+                {sameSite: "Lax"},
             )
             groups_token = JSON.parse(info).groups_token
         } else {
@@ -151,12 +152,12 @@ export const AppProvider = ({ cache, children }) => {
         get_read_write_privileges()
             .then((read_write_privileges) => {
                 if (read_write_privileges.read_privs === true) {
-                    setCookie(authKey, true)
+                    setCookie(authKey, true, {sameSite: "Lax"})
                     let info = getCookie('info')
                     if (info) {
                         info = atob(info)
                         const {email, globus_id} = JSON.parse(info)
-                        setCookie('user', {email, globus_id})
+                        setCookie('user', {email, globus_id}, {sameSite: "Lax"})
                     }
                     // Redirect to home page without query string
                     const page = getLocalItemWithExpiry(pageKey)
@@ -278,7 +279,7 @@ export const AppProvider = ({ cache, children }) => {
         if (!uiAuthCookie) {
             const result = await promptForUIPasscode()
             if (result.value === atob(getUIPassword())) {
-                setCookie('adminUIAuthorized', true)
+                setCookie('adminUIAuthorized', true, {sameSite: "Lax"})
                 setUIAuthorized(true)
             } else {
                 await checkUIPassword()

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -3,9 +3,9 @@ import {Sui} from "search-ui/lib/search-tools";
 import {getCookieDomain} from "../config/config";
 
 export function deleteCookies() {
-    setCookie('isAuthenticated', false)
+    setCookie('isAuthenticated', false, {sameSite: "Lax"})
     deleteCookie('groups_token')
-    deleteCookie('info', {path: '/', domain: getCookieDomain()})
+    deleteCookie('info', {path: '/', domain: getCookieDomain(), sameSite: "Lax"})
     deleteCookie('user')
     deleteCookie('adminUIAuthorized')
     localStorage.removeItem('userPage')

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,7 +19,8 @@ export default function Home() {
                 info = atob(info)
                 setCookie(
                     'groups_token',
-                    JSON.parse(info).groups_token
+                    JSON.parse(info).groups_token,
+                    {sameSite: "Lax"},
                 )
 
                 log.debug(router.query)


### PR DESCRIPTION
There are still some cookies set by Globus and Analytics with no SameSite value. I don't believe we have control of those though.