### PR TITLE
Displaying dataset display_subtype in badge

### DIFF
--- a/src/pages/dataset.jsx
+++ b/src/pages/dataset.jsx
@@ -174,7 +174,7 @@ function ViewDataset() {
                                     <SidebarBtn/>
 
                                     <EntityViewHeader data={data}
-                                                      uniqueHeader={data.dataset_type}
+                                                      uniqueHeader={data.display_subtype || data.dataset_type}
                                                       entity={cache.entities.dataset.toLowerCase()}
                                                       hasWritePrivilege={hasWritePrivilege}/>
 


### PR DESCRIPTION
Addresses #1207 

Changes
- Changed the dataset badge to display the `display_subtype` property instead of `dataset_type`