### PR TITLE
Libpitt/1353 progress bar

### DIFF
--- a/src/context/DerivedContext.jsx
+++ b/src/context/DerivedContext.jsx
@@ -41,7 +41,8 @@ export const DerivedProvider = ({children}) => {
         // Determine whether to show the Vitessce visualizations and where to pull data from
         //Check that this dataset has a valid status and has descendants or if we know this isn't a primary dataset
         if (isDatasetStatusPassed(data) && ((is_primary_dataset && data.descendants.length !== 0) || !is_primary_dataset)) {
-            if (!is_primary_dataset) {
+            // Add a check if this is a component dataset
+            if (!is_primary_dataset && data.dataset_category !== 'component') {
                 setShowVitessce(true)
                 await set_vitessce_config(data, data.uuid, dataset_type)
 

--- a/src/pages/user/jobs.jsx
+++ b/src/pages/user/jobs.jsx
@@ -213,7 +213,7 @@ function ViewJobs({isAdmin = false}) {
         }
 
         if (eq(action, 'register')) {
-            let registerRes = await fetch(urlPrefix() + `/${row.job_id}`)
+            let registerRes = await fetch(urlPrefix() + `/${row.job_id}`, {headers: get_headers()})
             if (registerRes.ok) {
                 let jobInfo = await registerRes.json()
                 setData([...data, jobInfo])

--- a/src/pages/user/jobs.jsx
+++ b/src/pages/user/jobs.jsx
@@ -91,14 +91,31 @@ function ViewJobs({isAdmin = false}) {
 
     const hasRegistered = (row) => {
         if (colorMap.current[row.job_id]) return true
-        for (let item of data) {
-           if (item.referrer.path.includes(row.job_id) && eq(item.referrer.type, 'register')) {
-               let color = randomColor()
-               colorMap.current[row.job_id] = color
-               colorMap.current[item.job_id] = color
-               return true
-           }
+
+        // check the validation job for a register_job_id prob
+        const registerJobId = row.register_job_id
+        const createColorMap = (item) => {
+            let color = randomColor()
+            colorMap.current[row.job_id] = color
+            colorMap.current[item.job_id] = color
+            return true
         }
+
+        if (registerJobId) {
+            for (let item of data) {
+                if (eq(item.job_id, registerJobId)) {
+                    return createColorMap(item)
+                }
+            }
+        }
+
+        // For backwards compatibility only, since old jobs prior to feature change may not have a register_job_id attached
+        for (let item of data) {
+            if (item.referrer.path.includes(row.job_id) && eq(item.referrer.type, 'register')) {
+                return createColorMap(item)
+            }
+        }
+
         return null
     }
 


### PR DESCRIPTION
Change log:
1. Check if validation job was registered or not; if registered:
- disable _Next_ button
- prevent running of entity/metadata registration calls
- show alert informing user the job was already registered

2. Use `register_job_id` prop to determine grouping and _Register_ action, so even if related register job is deleted, _Register_ action will not show again