### PR TITLE
Updating logic for edit dataset pages to not pass 'status' when updat…

### DIFF
--- a/src/components/custom/edit/dataset/AncestorIds.jsx
+++ b/src/components/custom/edit/dataset/AncestorIds.jsx
@@ -47,7 +47,7 @@ function BodyContent({ handleChangeAncestor }) {
 }
 
 export default function AncestorIds({values, onChange, fetchAncestors, deleteAncestor, ancestors, otherWithAdd, onShowModal, formLabelPlural,
-                                        formLabel = 'ancestor', controlId = 'direct_ancestor_uuids'}) {
+                                        formLabel = 'ancestor', controlId = 'direct_ancestor_uuids', dataset_category}) {
     const [showHideModal, setShowHideModal] = useState(false)
 
     useEffect(() => {
@@ -121,11 +121,12 @@ export default function AncestorIds({values, onChange, fetchAncestors, deleteAnc
             {/*Ancestor Information Box*/}
             {ancestors && ancestors.length !== 0 &&
                 <AncestorsTable controlId={controlId} formLabel={formLabel} values={values} onChange={onChange}
-                                ancestors={ancestors} deleteAncestor={deleteAncestor}/>
+                                ancestors={ancestors} deleteAncestor={deleteAncestor} dataset_category={dataset_category}/>
             }
 
+            {/*Disable the button if the dataset is not 'primary'*/}
             <InputGroup className="mb-3 ancestor-ctas" id="direct_ancestor_uuid_button">
-                <Button variant="outline-primary rounded-0 mt-1" onClick={showModal} aria-controls='js-modal'>
+                <Button variant="outline-primary rounded-0 mt-1" onClick={showModal} aria-controls='js-modal' disabled={dataset_category!=='primary'}>
                     Add another {formLabel} <i className="bi bi-plus-lg"></i>
                 </Button>
                 {otherWithAdd}

--- a/src/components/custom/edit/dataset/AncestorsTable.jsx
+++ b/src/components/custom/edit/dataset/AncestorsTable.jsx
@@ -5,7 +5,7 @@ import SenNetPopover from "../../../SenNetPopover";
 import ClipboardCopy from "../../../ClipboardCopy";
 import DataTable from "react-data-table-component";
 
-export default function AncestorsTable({formLabel, onChange, deleteAncestor, values, controlId, ancestors}) {
+export default function AncestorsTable({formLabel, onChange, deleteAncestor, values, controlId, ancestors, dataset_category}) {
     const _deleteAncestor = async (e, ancestorId) => {
         const old_uuids = [...values[controlId]]
         let updated_uuids = old_uuids.filter(e => e !== ancestorId)
@@ -57,7 +57,8 @@ export default function AncestorsTable({formLabel, onChange, deleteAncestor, val
                 selector: row => null,
                 sortable: false,
                 format: col => {
-                    return <Button className="pt-0 pb-0" variant="link" onClick={(e) => _deleteAncestor(e, col.uuid)}><i className={'bi bi-trash-fill'}
+                    // Disable this button when the dataset is not 'primary'
+                    return <Button className="pt-0 pb-0" variant="link" onClick={(e) => _deleteAncestor(e, col.uuid)} disabled={dataset_category!=='primary'}><i className={'bi bi-trash-fill'}
                         style={{color:"red"}}/></Button>
                 },
             },

--- a/src/context/DerivedContext.jsx
+++ b/src/context/DerivedContext.jsx
@@ -40,9 +40,9 @@ export const DerivedProvider = ({children}) => {
 
         // Determine whether to show the Vitessce visualizations and where to pull data from
         //Check that this dataset has a valid status and has descendants or if we know this isn't a primary dataset
-        if (isDatasetStatusPassed(data) && ((is_primary_dataset && data.descendants.length !== 0) || !is_primary_dataset)) {
+        if (isDatasetStatusPassed(data) && ((is_primary_dataset && data.descendants.length !== 0) || !is_primary_dataset) && data.dataset_category !== 'component') {
             // Add a check if this is a component dataset
-            if (!is_primary_dataset && data.dataset_category !== 'component') {
+            if (!is_primary_dataset) {
                 setShowVitessce(true)
                 await set_vitessce_config(data, data.uuid, dataset_type)
 

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -227,7 +227,7 @@ export default function EditDataset() {
         setModalDetails({
             entity: cache.entities.dataset,
             type: (response.dataset_type ? response.dataset_type : null),
-            typeHeader: _t('Data Type'),
+            typeHeader: _t('Dataset Type'),
             response
         })
     }
@@ -332,9 +332,17 @@ export default function EditDataset() {
                 if (values['group_uuid'] === null && editMode === 'Register') {
                     values['group_uuid'] = selectedUserWriteGroupUuid
                 }
+
                 // Remove empty strings
-                let json = cleanJson(values);
+                let json = cleanJson({...values});
                 let uuid = data.uuid
+
+                 // Remove 'status' from values. Not a field to pass to Entity API for a normal update of Dataset
+                delete json['status']
+                // If dataset is not `primary` then don't send direct_ancestor_uuids
+                if (data.dataset_category !== 'primary') {
+                    delete json['direct_ancestor_uuids']
+                }
 
                 await update_create_dataset(uuid, json, editMode).then((response) => {
                     modalResponse(response)
@@ -415,7 +423,7 @@ export default function EditDataset() {
                                     {/*Ancestor IDs*/}
                                     {/*editMode is only set when page is ready to load */}
                                     {editMode &&
-                                        <AncestorIds values={values} ancestors={ancestors} onChange={onChange}
+                                        <AncestorIds values={values} ancestors={ancestors} onChange={onChange} dataset_category={data.dataset_category}
                                                      fetchAncestors={fetchAncestors} deleteAncestor={deleteAncestor}/>
                                     }
 


### PR DESCRIPTION
…ing other properties. Non-primary datasets can no longer edit ancestor table and will not pass direct_ancestor_uuids property