### PR TITLE
Expanding relavant searched facets in search page

### DIFF
--- a/src/components/custom/organ/DataTypeQuantities.jsx
+++ b/src/components/custom/organ/DataTypeQuantities.jsx
@@ -1,10 +1,14 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import DataTable from "react-data-table-component";
+import useLocalSettings from "../../../hooks/useLocalSettings";
 import { getOrganDataTypeQuantities } from "../../../lib/services";
 import SenNetAccordion from "../layout/SenNetAccordion";
 
 const DataTypeQuantities = ({ id, ruiCode }) => {
+    const router = useRouter();
+    const {setLocalSettings} = useLocalSettings();
     const [dataTypes, setDataTypes] = useState(null);
 
     useEffect(() => {
@@ -40,6 +44,27 @@ const DataTypeQuantities = ({ id, ruiCode }) => {
         );
     };
 
+    const handleSearchPageClick = (e) => {
+        e.preventDefault();
+        // Expand the relevant facets on the search page
+        setLocalSettings("entities", {
+            "entity_type": { isExpanded: true },
+            "origin_sample.organ": { isExpanded: true },
+        })
+        router.push(searchUrl);
+    }
+
+    const handleDatasetTypeRowClick = (e, datasetType) => {
+        e.preventDefault();
+        // Expand the relevant facets on the search page
+        setLocalSettings("entities", {
+            "entity_type": { isExpanded: true },
+            "origin_sample.organ": { isExpanded: true },
+            "dataset_type": { isExpanded: true },
+        })
+        router.push(searchUrlForDatasetType(datasetType));
+    }
+
     const columns = [
         {
             name: "Dataset Type",
@@ -47,7 +72,8 @@ const DataTypeQuantities = ({ id, ruiCode }) => {
             cell: (row, index, column, id) => {
                 return (
                     <Link
-                        href={searchUrlForDatasetType(row.dataType)}
+                        href=""
+                        onClick={(e) => handleDatasetTypeRowClick(e, row.dataType)}
                     >
                         {row.dataType}
                     </Link>
@@ -66,7 +92,8 @@ const DataTypeQuantities = ({ id, ruiCode }) => {
             <div className="d-flex flex-row-reverse">
                 <Link
                     className="btn btn-outline-primary rounded-0"
-                    href={searchUrl}
+                    href=""
+                    onClick={handleSearchPageClick}
                 >
                     View on search page
                 </Link>

--- a/src/components/custom/organ/Samples.jsx
+++ b/src/components/custom/organ/Samples.jsx
@@ -1,12 +1,16 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import DataTable from "react-data-table-component";
-import { getSamplesByOrgan } from "../../../lib/services";
-import SenNetAccordion from "../layout/SenNetAccordion";
 import { APP_ROUTES } from "../../../config/constants";
+import useLocalSettings from "../../../hooks/useLocalSettings";
+import { getSamplesByOrgan } from "../../../lib/services";
 import ClipboardCopy from "../../ClipboardCopy";
+import SenNetAccordion from "../layout/SenNetAccordion";
 
 const Samples = ({ id, ruiCode }) => {
+    const router = useRouter();
+    const {setLocalSettings} = useLocalSettings();
     const [samples, setSamples] = useState(null);
 
     useEffect(() => {
@@ -64,12 +68,23 @@ const Samples = ({ id, ruiCode }) => {
         `filters%5B1%5D%5Bvalues%5D%5B0%5D=${ruiCode}&filters%5B1%5D%5Btype%5D=any&` +
         "sort%5B0%5D%5Bfield%5D=last_modified_timestamp&sort%5B0%5D%5Bdirection%5D=desc";
 
+    const handleSearchPageClick = (e) => {
+        e.preventDefault();
+        // Expand the relevant facets on the search page
+        setLocalSettings("entities", {
+            "entity_type": { isExpanded: true },
+            "organ": { isExpanded: true },
+        })
+        router.push(searchUrl);
+    }
+
     return (
         <SenNetAccordion id={id} title="Samples" afterTitle={undefined}>
             <div className="d-flex flex-row-reverse">
                 <Link
                     className="btn btn-outline-primary rounded-0"
-                    href={searchUrl}
+                    href=""
+                    onClick={handleSearchPageClick}
                 >
                     View on search page
                 </Link>

--- a/src/hooks/useLocalSettings.js
+++ b/src/hooks/useLocalSettings.js
@@ -1,0 +1,36 @@
+/**
+ * Settings stored in local storage.
+ * @typedef {Object} LocalSetting
+ * @property {boolean} isExpanded - Whether the facet is expanded.
+ */
+
+function useLocalSettings() {
+    /**
+     * Retrieves a settings object from local storage.
+     * The settings object is retrieved using a key that is a combination of the provided name and the string '.settings'.
+     * The settings object is parsed from a JSON string to an object before being returned.
+     * If no settings object is found, an empty object is returned.
+     *
+     * @param {string} name - The name to use as the base of the storage key.
+     * @return {Object<string,LocalSetting>} The retrieved settings object.
+     */
+    function getLocalSettings(name) {
+        return JSON.parse(localStorage.getItem(`${name}.settings`)) || {}
+    }
+
+    /**
+     * Stores a settings object in the local storage.
+     * The settings object is stored under a key that is a combination of the provided name and the string '.settings'.
+     * The settings object is converted to a JSON string before being stored.
+     *
+     * @param {string} name - The name to use as the base of the storage key.
+     * @param {Object<string,LocalSetting>} settings - The settings object to store. The key is the facet name and the value is the settings object.
+     */
+    function setLocalSettings(name, settings) {
+        localStorage.setItem(`${name}.settings`, JSON.stringify(settings))
+    }
+
+    return {getLocalSettings, setLocalSettings}
+}
+
+export default useLocalSettings


### PR DESCRIPTION
This is based on a very small issue I saw in the SenNet demo

Changes
- Expand the relevant facets on the search page when the `View on search page` link is clicked on organ detail page