### PR TITLE
Libpitt/3947 blamefields

### DIFF
--- a/src/components/custom/edit/GroupSelect.js
+++ b/src/components/custom/edit/GroupSelect.js
@@ -3,7 +3,8 @@ import {Form} from 'react-bootstrap';
 import SenNetPopover from "../../SenNetPopover";
 import AppContext from "../../../context/AppContext";
 
-const GroupSelect = ({groups, onGroupSelectChange, entity_type, plural, popover, value, title = 'Group', controlId='group_uuid', required = true, optionValueProp = 'uuid'}) => {
+const GroupSelect = ({groups, onGroupSelectChange, entity_type, plural, popover, value, isDisabled,
+                         title = 'Group', controlId='group_uuid', required = true, optionValueProp = 'uuid'}) => {
     const {cache} = useContext(AppContext)
     popover = popover || <>{`You are a member of more than one Globus group and need to pick a group to associate with ${plural ? 'these ' : 'this '}`}
         <code>{cache.entities[entity_type]}</code>.</>
@@ -18,7 +19,7 @@ const GroupSelect = ({groups, onGroupSelectChange, entity_type, plural, popover,
 
                 </Form.Label>
 
-                <Form.Select required={required} aria-label="group-select"
+                <Form.Select disabled={isDisabled} required={required} aria-label="group-select"
                              onChange={e => onGroupSelectChange(e, e.target.id, e.target.value)}>
                     <option value="">----</option>
                     {

--- a/src/components/custom/layout/entity/FormGroup.jsx
+++ b/src/components/custom/layout/entity/FormGroup.jsx
@@ -5,7 +5,8 @@ import AppContext from '../../../../context/AppContext'
 import SenNetPopover from "../../../SenNetPopover";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 
-function EntityFormGroup({ controlId, label, text, onChange, value, type, placeholder, isRequired, pattern, popoverTrigger, className, warningText, onBlur }) {
+function EntityFormGroup({ controlId, label, text, onChange, value, type, placeholder,
+                             isRequired, pattern, popoverTrigger, className, warningText, onBlur, isDisabled }) {
   const {_t } = useContext(AppContext)
   const isTextarea = (type === 'textarea')
 
@@ -19,12 +20,12 @@ function EntityFormGroup({ controlId, label, text, onChange, value, type, placeh
                 </SenNetPopover>
 
             </Form.Label>
-            {!isTextarea && <Form.Control type={type}  defaultValue={value} placeholder={_t(placeholder)} required={isRequired}
+            {!isTextarea && <Form.Control disabled={isDisabled} type={type}  defaultValue={value} placeholder={_t(placeholder)} required={isRequired}
                         pattern={pattern}
                         onBlur={onBlur ? (e => onBlur(e, e.target.id, e.target.value)) : undefined}
                         onChange={e => onChange(e, e.target.id, e.target.value)} /> }
 
-            {isTextarea && <Form.Control as={type} rows={4} defaultValue={value}
+            {isTextarea && <Form.Control disabled={isDisabled} as={type} rows={4} defaultValue={value}
                                          required={isRequired}
                         onBlur={onBlur ? (e => onBlur(e, e.target.id, e.target.value)) : undefined}
                         onChange={e => onChange(e, e.target.id, e.target.value)} /> }

--- a/src/components/custom/layout/entity/VersionsDropdown.jsx
+++ b/src/components/custom/layout/entity/VersionsDropdown.jsx
@@ -2,10 +2,8 @@ import {useContext, useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import Dropdown from 'react-bootstrap/Dropdown'
 import AppContext from "../../../../context/AppContext";
-import {getEntityEndPoint} from "../../../../config/config";
 import {getEntityViewUrl} from "../../js/functions";
 import Select from 'react-select'
-import {get_headers} from "../../../../lib/services";
 
 function VersionsDropdown({data}) {
 

--- a/src/components/custom/layout/entity/ViewHeader.jsx
+++ b/src/components/custom/layout/entity/ViewHeader.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import ClipboardCopy from "../../../ClipboardCopy";
 import {ViewHeaderBadges} from "./ViewHeaderBadges";
 import SenNetPopover from "../../../SenNetPopover";
-import VersionsDropdown from "./VersionsDropdown";
+import VersionDropdown from "./VersionDropdown";
 
 const EntityViewHeaderButtons = ({entity, data, hasWritePrivilege}) => {
     const {_t, cache} = useContext(AppContext)
@@ -29,7 +29,9 @@ const EntityViewHeaderButtons = ({entity, data, hasWritePrivilege}) => {
                             variant="outline-primary rounded-0"><i className="bi bi-filetype-json"></i></Button>
                 </SenNetPopover>
 
-                {eq(entity, cache.entities.dataset) && data.multi_revisions && <VersionsDropdown data={data}/>}
+                {eq(entity, cache.entities.dataset) && eq(data.status, 'published') &&
+                    <VersionDropdown data={data}/>
+                }
             </Stack>
 
         </div>

--- a/src/context/EntityContext.jsx
+++ b/src/context/EntityContext.jsx
@@ -252,6 +252,20 @@ export const EntityProvider = ({ children }) => {
         />
     }
 
+    const isAdminOrHasValue = (adminGroup, key) => (data[key] || adminGroup)
+
+    const getAssignedToGroupNames = (adminGroup) => {
+        if (adminGroup) {
+            return userWriteGroups.map(item => {if (item.data_provider) return item})
+        } else {
+            return [
+                {
+                    displayname: data.assigned_to_group_name
+                }
+            ]
+        }
+    }
+
     return (
         <EntityContext.Provider
             value={{
@@ -275,7 +289,8 @@ export const EntityProvider = ({ children }) => {
                 dataAccessPublic, setDataAccessPublic,
                 getEntityConstraints, getSampleEntityConstraints, buildConstraint,
                 getMetadataNote, successIcon, errIcon, checkProtocolUrl,
-                warningClasses, setWarningClasses, getCancelBtn
+                warningClasses, setWarningClasses, getCancelBtn,
+                isAdminOrHasValue, getAssignedToGroupNames
             }}
         >
             {children}

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -31,7 +31,6 @@ import {
     getIngestEndPoint,
     valid_dataset_ancestor_config
 } from "../../config/config";
-import AttributesUpload from "../../components/custom/edit/AttributesUpload";
 import $ from 'jquery'
 import SenNetPopover from "../../components/SenNetPopover"
 import DatasetSubmissionButton from "../../components/custom/edit/dataset/DatasetSubmissionButton";
@@ -53,7 +52,8 @@ export default function EditDataset() {
         dataAccessPublic, setDataAccessPublic,
         getEntityConstraints,
         getSampleEntityConstraints,
-        buildConstraint, successIcon, errIcon, getCancelBtn
+        buildConstraint, successIcon, errIcon, getCancelBtn,
+        isAdminOrHasValue, getAssignedToGroupNames
     } = useContext(EntityContext)
     const {_t, cache, adminGroup, isLoggedIn, getBusyOverlay, toggleBusyOverlay} = useContext(AppContext)
     const router = useRouter()
@@ -372,7 +372,6 @@ export default function EditDataset() {
         setContainsHumanGeneticSequences(false)
     }
 
-    const isAdminOrHasValue = (key) => (data[key] || adminGroup)
 
     if (isAuthorizing() || isUnauthorized()) {
         return (
@@ -409,7 +408,7 @@ export default function EditDataset() {
                                             entity_type={'dataset'}/>
                                     }
                                     {
-                                        !(userWriteGroups.length === 1) && isAdminOrHasValue('assigned_to_group_name') && isEditMode() &&
+                                        isAdminOrHasValue(adminGroup, 'assigned_to_group_name') && isEditMode() &&
                                         <GroupSelect
                                             optionValueProp={'displayname'}
                                             isDisabled={!adminGroup}
@@ -419,13 +418,13 @@ export default function EditDataset() {
                                             popover={<>The group responsible for the next step in the data ingest process.</>}
                                             data={data}
                                             value={data.assigned_to_group_name}
-                                            groups={userWriteGroups.map(item => {if (item.data_provider) return item})}
+                                            groups={getAssignedToGroupNames(adminGroup)}
                                             onGroupSelectChange={onChange}
                                             entity_type={'dataset'}/>
                                     }
 
                                     {/*/!*Ingest*!/*/}
-                                    {isEditMode() && isAdminOrHasValue('ingest_task') &&
+                                    {isEditMode() && isAdminOrHasValue(adminGroup, 'ingest_task') &&
                                         <EntityFormGroup label='Ingest Task'
                                                          isDisabled={!adminGroup}
                                            type={'textarea'}

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -372,6 +372,7 @@ export default function EditDataset() {
         setContainsHumanGeneticSequences(false)
     }
 
+    const isAdminOrHasValue = (key) => (data[key] || adminGroup)
 
     if (isAuthorizing() || isUnauthorized()) {
         return (
@@ -408,9 +409,10 @@ export default function EditDataset() {
                                             entity_type={'dataset'}/>
                                     }
                                     {
-                                        !(userWriteGroups.length === 1) && isEditMode() && adminGroup &&
+                                        !(userWriteGroups.length === 1) && isAdminOrHasValue('assigned_to_group_name') && isEditMode() &&
                                         <GroupSelect
                                             optionValueProp={'displayname'}
+                                            isDisabled={!adminGroup}
                                             title={'Assigned to Group Name'}
                                             required={false}
                                             controlId={'assigned_to_group_name'}
@@ -423,8 +425,9 @@ export default function EditDataset() {
                                     }
 
                                     {/*/!*Ingest*!/*/}
-                                    {isEditMode() && adminGroup &&
+                                    {isEditMode() && isAdminOrHasValue('ingest_task') &&
                                         <EntityFormGroup label='Ingest Task'
+                                                         isDisabled={!adminGroup}
                                            type={'textarea'}
                                         controlId='ingest_task' value={data.ingest_task}
                                         onChange={onChange}

--- a/src/pages/edit/upload.jsx
+++ b/src/pages/edit/upload.jsx
@@ -184,6 +184,8 @@ function EditUpload() {
         handlePut('reorganize')
     }
 
+    const isAdminOrHasValue = (key) => (data[key] || adminGroup)
+
     if (isAuthorizing() || isUnauthorized()) {
         return (
             isUnauthorized() ? <Unauthorized/> : <Spinner/>
@@ -243,9 +245,10 @@ function EditUpload() {
                                         }
 
                                         {
-                                            !(userWriteGroups.length === 1) && isEditMode() && adminGroup &&
+                                            !(userWriteGroups.length === 1) && isAdminOrHasValue('assigned_to_group_name') && isEditMode() &&
                                             <GroupSelect
                                                 optionValueProp={'displayname'}
+                                                isDisabled={!adminGroup}
                                                 title={'Assigned to Group Name'}
                                                 required={false}
                                                 controlId={'assigned_to_group_name'}
@@ -258,8 +261,9 @@ function EditUpload() {
                                         }
 
                                         {/*/!*Ingest*!/*/}
-                                        {isEditMode() && adminGroup &&
+                                        {isEditMode() && isAdminOrHasValue('ingest_task') &&
                                             <EntityFormGroup label='Ingest Task'
+                                                             isDisabled={!adminGroup}
                                                              type={'textarea'}
                                                              controlId='ingest_task' value={data.ingest_task}
                                                              onChange={onChange}

--- a/src/pages/edit/upload.jsx
+++ b/src/pages/edit/upload.jsx
@@ -36,7 +36,7 @@ function EditUpload() {
         selectedUserWriteGroupUuid,
         disableSubmit, setDisableSubmit,
         dataAccessPublic, setDataAccessPublic,
-        getCancelBtn
+        getCancelBtn, isAdminOrHasValue, getAssignedToGroupNames
     } = useContext(EntityContext)
     const {_t, cache, adminGroup, getBusyOverlay, toggleBusyOverlay} = useContext(AppContext)
 
@@ -184,8 +184,6 @@ function EditUpload() {
         handlePut('reorganize')
     }
 
-    const isAdminOrHasValue = (key) => (data[key] || adminGroup)
-
     if (isAuthorizing() || isUnauthorized()) {
         return (
             isUnauthorized() ? <Unauthorized/> : <Spinner/>
@@ -245,7 +243,7 @@ function EditUpload() {
                                         }
 
                                         {
-                                            !(userWriteGroups.length === 1) && isAdminOrHasValue('assigned_to_group_name') && isEditMode() &&
+                                            isAdminOrHasValue(adminGroup, 'assigned_to_group_name') && isEditMode() &&
                                             <GroupSelect
                                                 optionValueProp={'displayname'}
                                                 isDisabled={!adminGroup}
@@ -255,13 +253,13 @@ function EditUpload() {
                                                 popover={<>The group responsible for the next step in the data ingest process.</>}
                                                 data={data}
                                                 value={data.assigned_to_group_name}
-                                                groups={userWriteGroups.map(item => {if (item.data_provider) return item})}
+                                                groups={getAssignedToGroupNames(adminGroup)}
                                                 onGroupSelectChange={onChange}
                                                 entity_type={'dataset'}/>
                                         }
 
                                         {/*/!*Ingest*!/*/}
-                                        {isEditMode() && isAdminOrHasValue('ingest_task') &&
+                                        {isEditMode() && isAdminOrHasValue(adminGroup, 'ingest_task') &&
                                             <EntityFormGroup label='Ingest Task'
                                                              isDisabled={!adminGroup}
                                                              type={'textarea'}


### PR DESCRIPTION
Change log:
1. Add ability to disable text field or select dropdown
2. Add logic to disable `ingest_task` and `assigned_to_group_name` for now admins (if these fields are empty, they won't display at all for non-admins, no need to show empty disabled fields to users or ...)
3. Revert back to single revision dropdown