### PR TITLE
Prevent self referencing in Sample and Dataset edit for ancestors - #…

### DIFF
--- a/src/components/custom/edit/dataset/AncestorIds.jsx
+++ b/src/components/custom/edit/dataset/AncestorIds.jsx
@@ -19,7 +19,7 @@ import FacetsContent from '../../search/FacetsContent';
 import SearchUIContext from 'search-ui/components/core/SearchUIContext';
 import AppContext from "../../../../context/AppContext";
 
-function BodyContent({ handleChangeAncestor }) {
+function BodyContent({ handleChangeAncestor, data }) {
     const { wasSearched, filters } = useContext(SearchUIContext)
     const {hasAuthenticationCookie, isUnauthorized } = useContext(AppContext)
     const addConditional = (key, entity) => {
@@ -31,6 +31,11 @@ function BodyContent({ handleChangeAncestor }) {
 
     addConditional('rui_location','Sample' )
     addConditional('ancestors.rui_location', 'Dataset')
+
+    valid_dataset_ancestor_config['searchQuery']['excludeFilters'] = [{
+        keyword: "uuid.keyword",
+        value: data['uuid']
+    }]
 
     return (
         <div
@@ -47,7 +52,7 @@ function BodyContent({ handleChangeAncestor }) {
 }
 
 export default function AncestorIds({values, onChange, fetchAncestors, deleteAncestor, ancestors, otherWithAdd, onShowModal, formLabelPlural,
-                                        formLabel = 'ancestor', controlId = 'direct_ancestor_uuids', dataset_category, addButtonDisabled}) {
+                                        formLabel = 'ancestor', controlId = 'direct_ancestor_uuids', dataset_category, addButtonDisabled, data}) {
     const [showHideModal, setShowHideModal] = useState(false)
 
     useEffect(() => {
@@ -182,7 +187,7 @@ export default function AncestorIds({values, onChange, fetchAncestors, deleteAnc
                                 </div>
                             }
                             bodyContent={
-                                <BodyContent handleChangeAncestor={changeAncestor} />
+                                <BodyContent handleChangeAncestor={changeAncestor} data={data} />
                             }
                         />
                     </SearchUIContainer>

--- a/src/components/custom/edit/sample/AncestorId.jsx
+++ b/src/components/custom/edit/sample/AncestorId.jsx
@@ -1,4 +1,4 @@
-import React, {useContext, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 import {Form} from 'react-bootstrap';
 import {Results, SearchBox} from "@elastic/react-search-ui";
 import {Layout} from "@elastic/react-search-ui-views";
@@ -17,9 +17,10 @@ import SearchUIContext from 'search-ui/components/core/SearchUIContext';
 import FacetsContent from '../../search/FacetsContent';
 import AppContext from "../../../../context/AppContext";
 
-function BodyContent({ handleChangeSource }) {
+function BodyContent({ handleChangeSource, data }) {
     const {hasAuthenticationCookie, isUnauthorized } = useContext(AppContext)
     const { filters } = useContext(SearchUIContext)
+    const includedExclude = useRef(false)
 
     exclude_dataset_config['searchQuery']['conditionalFacets']['rui_location'] = ({filters}) => {
         return hasAuthenticationCookie() && !isUnauthorized() &&
@@ -27,6 +28,16 @@ function BodyContent({ handleChangeSource }) {
     }
 
     exclude_dataset_config['searchQuery']['conditionalFacets']['ancestors.rui_location'] = () => false
+
+    useEffect(() => {
+        if (!includedExclude.current) {
+            includedExclude.current = true
+            exclude_dataset_config['searchQuery']['excludeFilters'].push({
+                keyword: "uuid.keyword",
+                value: data['uuid']
+            })
+        }
+    }, [])
 
     return (
         <div className="js-gtm--results"
@@ -39,7 +50,7 @@ function BodyContent({ handleChangeSource }) {
     )
 }
 
-const AncestorId = ({fetchSource, onChange, source}) => {
+const AncestorId = ({fetchSource, onChange, source, data}) => {
     const [showHideModal, setShowHideModal] = useState(false)
 
     const handleSearchFormSubmit = (event, onSubmit) => {
@@ -134,7 +145,7 @@ const AncestorId = ({fetchSource, onChange, source}) => {
                                 </div>
                             }
                             bodyContent={
-                                <BodyContent handleChangeSource={changeSource} />
+                                <BodyContent handleChangeSource={changeSource} data={data} />
                             }
 
                         />

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -443,7 +443,7 @@ export default function EditDataset() {
                                     {/*Ancestor IDs*/}
                                     {/*editMode is only set when page is ready to load */}
                                     {editMode &&
-                                        <AncestorIds values={values} ancestors={ancestors} onChange={onChange}
+                                        <AncestorIds data={data} values={values} ancestors={ancestors} onChange={onChange}
                                                      dataset_category={data.dataset_category}
                                                      fetchAncestors={fetchAncestors} deleteAncestor={deleteAncestor}
                                                      addButtonDisabled={data.dataset_category != null && data.dataset_category !== 'primary' }/>

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -427,7 +427,7 @@ function EditSample() {
                                     {/*Ancestor ID*/}
                                     {/*editMode is only set when page is ready to load */}
                                     {editMode &&
-                                        <AncestorId source={source} onChange={_onChange} fetchSource={fetchSource}/>
+                                        <AncestorId data={data} source={source} onChange={_onChange} fetchSource={fetchSource}/>
                                     }
 
                                     {/*Source Information Box*/}


### PR DESCRIPTION
Change log:
1. Update search-api query to block from choosing current entity as ancestor.