### PR TITLE
Add logic to use first order on sort - #1572

### DIFF
--- a/src/context/TableResultsContext.jsx
+++ b/src/context/TableResultsContext.jsx
@@ -82,9 +82,10 @@ export const TableResultsProvider = ({ index, columnsRef, children, getHotLink, 
         sortedFields.current[field] = direction
         setSort(sorting)
 
-        // This is an unfortunate hack because react-data-table-component use defaultValue as Select prop,
+        // This is an unfortunate hack because react-data-table-component uses defaultValue as Select prop,
         // no value prop is exposed. We can either use our own custom Pagination component or
         // if we want to keep the one from react-data-table-component need to add a dynamic key prop to the DataTable component
+        // and manually apply these css classes to indicator sorting
         $('[role="columnheader"]').removeClass('is-activeSort')
         setTimeout(() => {
             $(`[data-column-id="${field}"][role="columnheader"]`).addClass(`is-activeSort`).attr('data-sort-direction', direction)

--- a/src/context/TableResultsContext.jsx
+++ b/src/context/TableResultsContext.jsx
@@ -58,9 +58,10 @@ export const TableResultsProvider = ({ index, columnsRef, children, getHotLink, 
         setPageNumber(page)
     }
 
-    const handleSort = (column) => {
+    const handleSort = (column, order) => {
         let sorting = []
         let field = column.id
+        if (sortedFields.current[field] === undefined) sortedFields.current[field] = order
         const direction = eq(sortedFields.current[field], 'desc') ? 'asc' : 'desc'
 
         const newSort = {


### PR DESCRIPTION
Change log:
1. Apply the first order as default in order to maintain correct toggling of sort