### PR TITLE
Restricting data table page number

### DIFF
--- a/src/context/TableResultsContext.jsx
+++ b/src/context/TableResultsContext.jsx
@@ -54,6 +54,9 @@ export const TableResultsProvider = ({ index, columnsRef, children, getHotLink, 
     }
 
     const updateTablePagination = (page, currentRowsPerPage) => {
+        if (page * currentRowsPerPage > 10000) {
+            page = Math.floor(10000 / currentRowsPerPage)
+        }
         setPageSize(currentRowsPerPage)
         setPageNumber(page)
     }


### PR DESCRIPTION
Elastic search has a limit of searching through 10000 entities. This is a temporary fix to prevent the app from crashing when the user tries to go to the last page of the table when the table has more than 10000.