### PR TITLE
Adding contains_data facet to search - #1710

### DIFF
--- a/src/config/search/entities.js
+++ b/src/config/search/entities.js
@@ -158,6 +158,17 @@ export const SEARCH_ENTITIES = {
                 isAggregationActive: doesTermFilterContainValues('entity_type', ['Sample']),
                 isFacetVisible: doesAggregationHaveBuckets('source.source_type')
             },
+            contains_data: {
+                label: 'Contains Data',
+                type: 'value',
+                field: 'contains_data.keyword',
+                isExpanded: false,
+                filterType: 'any',
+                isFilterable: false,
+                facetType: 'term',
+                isAggregationActive: doesTermFilterContainValues('entity_type', ['Sample']),
+                isFacetVisible: doesAggregationHaveBuckets('contains_data')
+            },
             has_rui_information: {
                 label: 'Is Spatially Registered',
                 type: 'value',


### PR DESCRIPTION
Related to [entity-api PR](https://github.com/sennetconsortium/entity-api/pull/511)

A few samples have been reindexed for testing

Changes
- Added `contains_data` facet  for filtering if a sample has descendant datasets associated with it