### PR TITLE
Fixing ancestor dataset metadata issue in table

### DIFF
--- a/src/components/custom/entities/Metadata.jsx
+++ b/src/components/custom/entities/Metadata.jsx
@@ -218,7 +218,7 @@ function Metadata({data, metadata, mappedMetadata, groups}) {
                                 // Handle dataset table
                                 // Datasets have their metadata inside "metadata.metadata"
                                 return (
-                                    tabPaneCommon('2', index, ancestor, ancestor.ingest_metadata.metadata, ancestor.cedar_mapped_metadata)
+                                    tabPaneCommon('2', index, ancestor, ancestor.metadata, ancestor.cedar_mapped_metadata)
                                 )
                             }
                         })}


### PR DESCRIPTION
This is branched off of dev-integrate to fix an issue with the top level metadata schema on dev. Don't merge into main.