### PR TITLE
Avoid calls to descendants endpoint for edit pages - #1816

### DIFF
--- a/src/components/custom/js/functions.js
+++ b/src/components/custom/js/functions.js
@@ -539,7 +539,7 @@ export const extractSourceSex = (source) => {
     // Default to `undefined`
     let sex = undefined
     // First check if Source has metadata
-    if ('metadata' in source) {
+    if (eq(source['source_type'], 'Human') && 'metadata' in source) {
         // Source metadata will have a top level object such as organ_donor_data or living_donor_data
         let metadataKey = Object.keys(source.metadata)[0]
         source.metadata[metadataKey].some(function (metadataObject) {

--- a/src/pages/edit/dataset.jsx
+++ b/src/pages/edit/dataset.jsx
@@ -158,7 +158,7 @@ export default function EditDataset() {
                 setErrorMessage(_data["error"])
             } else {
                 setData(_data)
-                const ancestry = await getAncestryData(_data.uuid, {otherEndpoints: ['immediate_ancestors']})
+                const ancestry = await getAncestryData(_data.uuid, {endpoints: ['ancestors'], otherEndpoints: ['immediate_ancestors']})
                 Object.assign(_data, ancestry)
                 setData(_data)
 

--- a/src/pages/edit/publication.jsx
+++ b/src/pages/edit/publication.jsx
@@ -66,7 +66,7 @@ export default function EditPublication() {
                 setErrorMessage(_data["error"])
             } else {
                 setData(_data)
-                const ancestry = await getAncestryData(_data.uuid, {otherEndpoints: ['immediate_ancestors']})
+                const ancestry = await getAncestryData(_data.uuid, {endpoints: ['ancestors'], otherEndpoints: ['immediate_ancestors']})
                 Object.assign(_data, ancestry)
                 setData(_data)
 

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -123,7 +123,7 @@ function EditSample() {
             } else {
 
                 setData(_data)
-                const ancestry = await getAncestryData(_data.uuid, {otherEndpoints: ['immediate_ancestors']})
+                const ancestry = await getAncestryData(_data.uuid, {endpoints: ['ancestors'], otherEndpoints: ['immediate_ancestors']})
                 Object.assign(_data, ancestry)
                 setData(_data)
                 setRuiSex(extractSourceSex(_data.source))


### PR DESCRIPTION
Change log:
1. Modify option `endpoints` to reduce calls for edit pages