### PR TITLE
Stringify value

### DIFF
--- a/src/hooks/useDataTableSearch.js
+++ b/src/hooks/useDataTableSearch.js
@@ -25,7 +25,7 @@ function useDataTableSearch({data, onKeydown, fieldsToSearch = [], className = '
         if (!data || !Array.isArray(data)) return []
         for (let searchIndex of fieldsToSearch) {
             for (let d of data) {
-                if (d[searchIndex] && d[searchIndex]?.toLowerCase().includes(filterText?.toLowerCase())) {
+                if (d[searchIndex] && `${d[searchIndex]}`.toLowerCase().includes(filterText?.toLowerCase())) {
                     if (results.indexOf(d) === -1) results.push(d);
                 }
             }


### PR DESCRIPTION
Issue:
![image](https://github.com/user-attachments/assets/6871c2a1-b1e6-4355-92ac-94f4eb4f8e8d)

Change log:
1. typeof `d[searchIndex]` may not always be a string value, stringify it
