### PR TITLE
Libpitt/1883 editform

### DIFF
--- a/src/components/custom/edit/sample/SampleCategory.jsx
+++ b/src/components/custom/edit/sample/SampleCategory.jsx
@@ -63,7 +63,7 @@ function SampleCategory({
                     {!isDisabled && <option value="">----</option>}
                     {Object.entries(sample_categories).map(sample_category => {
                         return (
-                            <option key={sample_category[0]} value={sample_category[0]} selected={sample_category[0] === data.sample_category}>
+                            <option key={sample_category[0]} value={sample_category[0]}>
                                 {sample_category[1]}
                             </option>
                         );

--- a/src/components/custom/edit/sample/SampleCategory.jsx
+++ b/src/components/custom/edit/sample/SampleCategory.jsx
@@ -63,7 +63,7 @@ function SampleCategory({
                     {!isDisabled && <option value="">----</option>}
                     {Object.entries(sample_categories).map(sample_category => {
                         return (
-                            <option key={sample_category[0]} value={sample_category[0]}>
+                            <option key={sample_category[0]} value={sample_category[0]} selected={sample_category[0] === data.sample_category}>
                                 {sample_category[1]}
                             </option>
                         );

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -122,6 +122,8 @@ function EditSample() {
                 if (ancestry.hasOwnProperty("immediate_ancestors")) {
                     fetchSource(ancestry.immediate_ancestors[0].uuid)
                         .catch(log.error);
+                } else {
+                    setSource(_data.source)
                 }
             }).catch(log.error)
 

--- a/src/pages/edit/sample.jsx
+++ b/src/pages/edit/sample.jsx
@@ -108,7 +108,6 @@ function EditSample() {
             setData(_data)
             setRuiSex(extractSourceSex(_data.source))
             checkProtocolUrl(_data.protocol_url)
-            setSource(_data.source)
 
             // Show organ input group if sample category is 'organ'
             if (eq(_data.sample_category, cache.sampleCategories.Organ)) {


### PR DESCRIPTION
Change log:
1. Prevent the setting of source twice which caused the ui to noticeably change 

@maxsibilla This looks like it was caused because of `setSource(_data.source)` being called and then setSource(..) being called again from call of `fetchSource(ancestry.immediate_ancestors[0].uuid)`. I am guessing the initial `setSource(_data.source)` is a fallback, so just put it in a else block. This solved the issue with the selected in Sample Category dropdown.