### PR TITLE
Update HRA EUI and organ-info config to display only primary datasets

### DIFF
--- a/src/components/custom/eui/EUIIntegration.js
+++ b/src/components/custom/eui/EUIIntegration.js
@@ -15,7 +15,7 @@ const EUIIntegration = () => {
             </Helmet>
             <ccf-eui
                 theme="sennet"
-                data-sources={`["https://apps.humanatlas.io/api/ds-graph/sennet?token=${getCookie('groups_token') ? getCookie('groups_token') : ''}"]`}
+                data-sources={`["https://apps.humanatlas.io/api/ds-graph/sennet?primary=true&token=${getCookie('groups_token') ? getCookie('groups_token') : ''}"]`}
                 base-href="https://cdn.humanatlas.io/ui/ccf-eui/"
                 logo-tooltip="SenNet Data Sharing Portal"
                 login-disabled="true"

--- a/src/components/custom/organ/CCFOrganInfo.jsx
+++ b/src/components/custom/organ/CCFOrganInfo.jsx
@@ -12,7 +12,7 @@ import { Helmet, HelmetProvider } from 'react-helmet-async'
  */
 const CCFOrganInfo = ({ organ }) => {
     // See https://github.com/hubmapconsortium/hra-ui/blob/47490b8b5977def6cbaed047ebda6beb9e90fb97/EMBEDDING.md?plain=1#L412
-    log.debug('https://apps.humanatlas.io/api/ds-graph/sennet?token=')
+    log.debug('https://apps.humanatlas.io/api/ds-graph/sennet?primary=true&token=')
     log.debug(getCookie('groups_token'))
 
     // This overrides some styles in the ccf-organ-info. Allows the organ view to expand to the full width of the parent.
@@ -42,7 +42,7 @@ const CCFOrganInfo = ({ organ }) => {
             </Helmet>
             <ccf-organ-info
                 organ-iri={organ.url}
-                data-sources={`["https://apps.humanatlas.io/api/ds-graph/sennet?token=${getCookie('groups_token') ? getCookie('groups_token') : ''}"]`}
+                data-sources={`["https://apps.humanatlas.io/api/ds-graph/sennet?primary=true&token=${getCookie('groups_token') ? getCookie('groups_token') : ''}"]`}
                 eui-url='https://data.sennetconsortium.org/ccf-eui'
                 rui-url='https://apps.humanatlas.io/rui/'
                 asctb-url='https://hubmapconsortium.github.io/ccf-asct-reporter/'


### PR DESCRIPTION
This PR updates the EUI and organ-info web components to only show primary datasets. This will get the number of datasets shown aligned with the SenNet data portal (when `Has Spatial Information` is set to true).
