### PR TITLE
Fix loading error for HRA Organ Info component

### DIFF
--- a/src/components/custom/organ/CCFOrganInfo.jsx
+++ b/src/components/custom/organ/CCFOrganInfo.jsx
@@ -36,7 +36,7 @@ const CCFOrganInfo = ({ organ }) => {
                 />
                 <script
                     src='https://cdn.humanatlas.io/ui/ccf-organ-info/wc.js'
-                    defer
+                    type="module"
                 ></script>
                 <style>{customStyles}</style>
             </Helmet>


### PR DESCRIPTION
Update ccf-organ-info to load as a module. Fixes loading error.