### PR TITLE
Use position-absolute class on loading

### DIFF
--- a/src/components/custom/Sankey.jsx
+++ b/src/components/custom/Sankey.jsx
@@ -111,7 +111,7 @@ function Sankey({maxHeight, showExpandButton = false}) {
     return (
         <div className={'c-sankey'}>
             {showExpandButton && <a href={'/sankey'} className={'c-sankey__btn btn btn-outline-primary icon-inline'}><span>Expand</span> <i className="bi bi-arrows-angle-expand"></i></a>}
-            {filters && options && <react-consortia-sankey ref={xacSankey} options={btoa(JSON.stringify({...options, dimensions: {
+            {filters && options && <react-consortia-sankey className={loading ? 'position-absolute' : ''} ref={xacSankey} options={btoa(JSON.stringify({...options, dimensions: {
                     desktopMaxHeight: sankeyHeight
                 } }))
             } /> }


### PR DESCRIPTION
Change log:
1. Use position-absolute class so loading skeleton is at top and visible during load time.
BEFORE:
<img width="1823" height="459" alt="Screenshot 2026-07-10 at 12 11 15 PM" src="https://github.com/user-attachments/assets/93ed659e-95dd-45d3-81c9-36d475ad3838" />

AFTER:
<img width="1831" height="486" alt="Screenshot 2026-07-10 at 12 11 26 PM" src="https://github.com/user-attachments/assets/196f1115-2317-4bdd-b6b2-f2035d862252" />
